### PR TITLE
feature: migrate Tooltip to multi-window

### DIFF
--- a/examples/api_multiwindow/lib/material/popup_menu/popup_menu.0.dart
+++ b/examples/api_multiwindow/lib/material/popup_menu/popup_menu.0.dart
@@ -1,0 +1,141 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [PopupMenuButton].
+
+void main() => runWidget(MultiWindowApp(initialWindows: [
+      (BuildContext context) => createRegular(
+          context: context,
+          size: const Size(800, 600),
+          builder: (BuildContext context) {
+            return const PopupMenuApp();
+          })
+    ]));
+
+class PopupMenuApp extends StatelessWidget {
+  const PopupMenuApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: PopupMenuExample(),
+    );
+  }
+}
+
+enum AnimationStyles { defaultStyle, custom, none }
+
+const List<(AnimationStyles, String)> animationStyleSegments =
+    <(AnimationStyles, String)>[
+  (AnimationStyles.defaultStyle, 'Default'),
+  (AnimationStyles.custom, 'Custom'),
+  (AnimationStyles.none, 'None'),
+];
+
+enum Menu { preview, share, getLink, remove, download }
+
+class PopupMenuExample extends StatefulWidget {
+  const PopupMenuExample({super.key});
+
+  @override
+  State<PopupMenuExample> createState() => _PopupMenuExampleState();
+}
+
+class _PopupMenuExampleState extends State<PopupMenuExample> {
+  Set<AnimationStyles> _animationStyleSelection = <AnimationStyles>{
+    AnimationStyles.defaultStyle
+  };
+  AnimationStyle? _animationStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.only(top: 50),
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                SegmentedButton<AnimationStyles>(
+                  selected: _animationStyleSelection,
+                  onSelectionChanged: (Set<AnimationStyles> styles) {
+                    setState(() {
+                      _animationStyleSelection = styles;
+                      switch (styles.first) {
+                        case AnimationStyles.defaultStyle:
+                          _animationStyle = null;
+                        case AnimationStyles.custom:
+                          _animationStyle = AnimationStyle(
+                            curve: Easing.emphasizedDecelerate,
+                            duration: const Duration(seconds: 3),
+                          );
+                        case AnimationStyles.none:
+                          _animationStyle = AnimationStyle.noAnimation;
+                      }
+                    });
+                  },
+                  segments: animationStyleSegments
+                      .map<ButtonSegment<AnimationStyles>>(
+                          ((AnimationStyles, String) segment) {
+                    return ButtonSegment<AnimationStyles>(
+                        value: segment.$1, label: Text(segment.$2));
+                  }).toList(),
+                ),
+                const SizedBox(height: 10),
+                PopupMenuButton<Menu>(
+                  popUpAnimationStyle: _animationStyle,
+                  icon: const Icon(Icons.more_vert),
+                  onSelected: (Menu item) {},
+                  itemBuilder: (BuildContext context) => <PopupMenuEntry<Menu>>[
+                    const PopupMenuItem<Menu>(
+                      value: Menu.preview,
+                      child: ListTile(
+                        leading: Icon(Icons.visibility_outlined),
+                        title: Text('Preview'),
+                      ),
+                    ),
+                    const PopupMenuItem<Menu>(
+                      value: Menu.share,
+                      child: ListTile(
+                        leading: Icon(Icons.share_outlined),
+                        title: Text('Share'),
+                      ),
+                    ),
+                    const PopupMenuItem<Menu>(
+                      value: Menu.getLink,
+                      child: ListTile(
+                        leading: Icon(Icons.link_outlined),
+                        title: Text('Get link'),
+                      ),
+                    ),
+                    const PopupMenuDivider(),
+                    const PopupMenuItem<Menu>(
+                      value: Menu.remove,
+                      child: ListTile(
+                        leading: Icon(Icons.delete_outline),
+                        title: Text('Remove'),
+                      ),
+                    ),
+                    const PopupMenuItem<Menu>(
+                      value: Menu.download,
+                      child: ListTile(
+                        leading: Icon(Icons.download_outlined),
+                        title: Text('Download'),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api_multiwindow/lib/material/tooltip/tooltip.0.dart
+++ b/examples/api_multiwindow/lib/material/tooltip/tooltip.0.dart
@@ -1,0 +1,46 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [Tooltip].
+
+void main() => runWidget(MultiWindowApp(initialWindows: [
+      (BuildContext context) => createRegular(
+          context: context,
+          size: const Size(800, 600),
+          builder: (BuildContext context) {
+            return const MaterialApp(home: TooltipExampleApp());
+          })
+    ]));
+
+class TooltipExampleApp extends StatelessWidget {
+  const TooltipExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme:
+          ThemeData(tooltipTheme: const TooltipThemeData(preferBelow: false)),
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Tooltip Sample')),
+        body: const Center(
+          child: TooltipSample(),
+        ),
+      ),
+    );
+  }
+}
+
+class TooltipSample extends StatelessWidget {
+  const TooltipSample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Tooltip(
+      message: 'I am a Tooltip',
+      child: Text('Hover over the text to show a tooltip.'),
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -12,6 +12,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -416,6 +417,48 @@ class Tooltip extends StatefulWidget {
   }
 }
 
+class _TooltipStateController {
+  _TooltipStateController({required bool useMultiWindow})
+    : _isMultiWindow = useMultiWindow {
+    if (useMultiWindow) {
+      _windowCreatorController = WindowCreatorController();
+    } else {
+      _overlayController = OverlayPortalController();
+    }
+  }
+
+  final bool _isMultiWindow;
+  late final OverlayPortalController _overlayController;
+  late final WindowCreatorController _windowCreatorController;
+  bool get isMultiWindow => _isMultiWindow;
+
+  OverlayPortalController get overlayController {
+    assert(!_isMultiWindow);
+    return _overlayController;
+  }
+
+  WindowCreatorController get windowCreatorController {
+    assert(_isMultiWindow);
+    return _windowCreatorController;
+  }
+
+  Future<void> show(BuildContext context) async {
+    if (!_isMultiWindow) {
+      _overlayController.show();
+    } else {
+      await _windowCreatorController.show(context);
+    }
+  }
+
+  Future<void> hide(BuildContext context) async {
+    if (!_isMultiWindow) {
+      _overlayController.hide();
+    } else {
+      await _windowCreatorController.hide(context);
+    }
+  }
+}
+
 /// Contains the state for a [Tooltip].
 ///
 /// This class can be used to programmatically show the Tooltip, see the
@@ -434,7 +477,7 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   static const bool _defaultEnableFeedback = true;
   static const TextAlign _defaultTextAlign = TextAlign.start;
 
-  final OverlayPortalController _overlayController = OverlayPortalController();
+  _TooltipStateController? _tooltipStateController;
 
   // From InheritedWidgets
   late bool _visible;
@@ -484,9 +527,9 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     switch ((_animationStatus.isDismissed, status.isDismissed)) {
       case (false, true):
         Tooltip._openedTooltips.remove(this);
-        _overlayController.hide();
+        _tooltipStateController!.hide(context);
       case (true, false):
-        _overlayController.show();
+        _tooltipStateController!.show(context);
         Tooltip._openedTooltips.add(this);
         SemanticsService.tooltip(_tooltipMessage);
       case (true, true) || (false, false):
@@ -756,13 +799,16 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     };
   }
 
-  Widget _buildTooltipOverlay(BuildContext context) {
-    final OverlayState overlayState = Overlay.of(context, debugRequiredFor: widget);
-    final RenderBox box = this.context.findRenderObject()! as RenderBox;
-    final Offset target = box.localToGlobal(
-      box.size.center(Offset.zero),
-      ancestor: overlayState.context.findRenderObject(),
-    );
+  Widget _buildTooltipOverlay(BuildContext context, bool isMultiWindow) {
+    Offset target = Offset.zero;
+    if (!isMultiWindow) {
+      final OverlayState overlayState = Overlay.of(context, debugRequiredFor: widget);
+      final RenderBox box = this.context.findRenderObject()! as RenderBox;
+      target = box.localToGlobal(
+        box.size.center(Offset.zero),
+        ancestor: overlayState.context.findRenderObject(),
+      );
+    }
 
     final (TextStyle defaultTextStyle, BoxDecoration defaultDecoration) = switch (Theme.of(context)) {
       ThemeData(brightness: Brightness.dark, :final TextTheme textTheme, :final TargetPlatform platform) => (
@@ -790,6 +836,7 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       target: target,
       verticalOffset: widget.verticalOffset ?? tooltipTheme.verticalOffset ?? _defaultVerticalOffset,
       preferBelow: widget.preferBelow ?? tooltipTheme.preferBelow ?? _defaultPreferBelow,
+      isMultiWindow: isMultiWindow,
     );
 
     return SelectionContainer.maybeOf(context) == null
@@ -817,6 +864,9 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
+    _tooltipStateController ??= _TooltipStateController(
+      useMultiWindow: MultiWindowAppContext.of(context) != null);
+
     // If message is empty then no need to create a tooltip overlay to show
     // the empty black container so just return the wrapped child as is or
     // empty container if child is not specified.
@@ -842,11 +892,51 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
         ),
       );
     }
-    return OverlayPortal(
-      controller: _overlayController,
-      overlayChildBuilder: _buildTooltipOverlay,
-      child: result,
-    );
+
+    if (_tooltipStateController!.isMultiWindow) {
+      final BuildContext parentContext = context;
+      final WindowContext windowContext = WindowContext.of(context)!;
+      return AutoSizedWindowCreator(
+          widgetBuilder: (BuildContext context) =>
+            _buildTooltipOverlay(context, true),
+          windowBuilder:
+              (WidgetBuilder builder, Size windowSize, Window parent) {
+            final RenderBox box = parentContext.findRenderObject()! as RenderBox;
+            final Offset position = box.localToGlobal(Offset.zero);
+            WindowPositionerAnchor parentAnchor = WindowPositionerAnchor.top;
+            WindowPositionerAnchor childAnchor = WindowPositionerAnchor.bottom;
+            if (widget.preferBelow ?? false) {
+              parentAnchor = WindowPositionerAnchor.bottom;
+              childAnchor = WindowPositionerAnchor.top;
+            }
+
+            return createPopup(
+                context: context,
+                parent: windowContext.window,
+                size: Size(windowSize.width + 1, windowSize.height),
+                anchorRect: Rect.fromPoints(
+                    position,
+                    Offset(position.dx + box.size.width,
+                        position.dy + box.size.height)),
+                positioner: WindowPositioner(
+                    parentAnchor: parentAnchor,
+                    childAnchor: childAnchor),
+                builder: (BuildContext context) {
+                  return MaterialApp(debugShowCheckedModeBanner: false,
+                    home: Scaffold(body: builder(context)));
+                });
+          },
+          controller: _tooltipStateController!.windowCreatorController,
+          child: result);
+    }
+    else {
+      return OverlayPortal(
+        controller: _tooltipStateController!.overlayController,
+        overlayChildBuilder: (BuildContext context) =>
+          _buildTooltipOverlay(context, false),
+        child: result,
+      );
+    }
   }
 }
 
@@ -911,6 +1001,7 @@ class _TooltipOverlay extends StatelessWidget {
     required this.preferBelow,
     this.onEnter,
     this.onExit,
+    this.isMultiWindow = false
   });
 
   final InlineSpan richMessage;
@@ -926,6 +1017,7 @@ class _TooltipOverlay extends StatelessWidget {
   final bool preferBelow;
   final PointerEnterEventListener? onEnter;
   final PointerExitEventListener? onExit;
+  final bool isMultiWindow;
 
   @override
   Widget build(BuildContext context) {
@@ -962,6 +1054,11 @@ class _TooltipOverlay extends StatelessWidget {
         child: result,
       );
     }
+
+    if (isMultiWindow) {
+      return result;
+    }
+
     return Positioned.fill(
       bottom: MediaQuery.maybeViewInsetsOf(context)?.bottom ?? 0.0,
       child: CustomSingleChildLayout(

--- a/packages/flutter/lib/src/widgets/window.dart
+++ b/packages/flutter/lib/src/widgets/window.dart
@@ -2,12 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show FlutterView;
+import 'dart:ui' show FlutterView, DartPerformanceMode;
 import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+
+const Duration _kMenuDuration = Duration(milliseconds: 300);
+const double _kMenuCloseIntervalEnd = 2.0 / 3.0;
 
 /// Defines the anchor point for the anchor rectangle or child [Window] when
 /// positioning a [Window]. The specified anchor is used to derive an anchor
@@ -1088,5 +1091,226 @@ class _WidgetSizeHelperState extends State<_WidgetSizeHelper>
         ),
       ),
     );
+  }
+}
+
+abstract class _WindowRoute<T> extends Route<T> {
+  _WindowRoute({
+    required BuildContext context,
+    Size? size,
+    this.onWindowOpened,
+    this.onWindowClosed,
+    super.settings,
+  })  : _context = context,
+        _size = size;
+
+  final BuildContext _context;
+  final Size? _size;
+  final void Function(Window)? onWindowOpened;
+  final void Function(Window)? onWindowClosed;
+  final WindowCreatorController _controller = WindowCreatorController();
+
+  @override
+  List<OverlayEntry> get overlayEntries => _overlayEntries;
+  final List<OverlayEntry> _overlayEntries = <OverlayEntry>[];
+
+  WidgetBuilder get builder;
+
+  Future<Window> _createWindow(
+      BuildContext context, WidgetBuilder builder, Size size, Window? parent);
+
+  @override
+  void install() {
+    assert(_overlayEntries.isEmpty);
+    _overlayEntries.add(OverlayEntry(builder: (BuildContext context) {
+      if (_size == null) {
+        return AutoSizedWindowCreator(
+            widgetBuilder: builder,
+            windowBuilder: (WidgetBuilder builder, Size size, Window window) {
+              return _createWindow(context, builder, size, window);
+            },
+            controller: _controller,
+            openImmediately: true,
+            onWindowOpened: onWindowOpened,
+            onWindowClosed: onWindowClosed,
+            child: Container());
+      } else {
+        return WindowCreator(
+            builder: (BuildContext context, Window window) {
+              final WindowContext? windowContext = WindowContext.of(_context);
+              return _createWindow(
+                  context, builder, _size, windowContext?.window);
+            },
+            controller: _controller,
+            openImmediately: true,
+            onWindowOpened: onWindowOpened,
+            onWindowClosed: onWindowClosed,
+            child: Container());
+      }
+    }));
+    super.install();
+  }
+
+  @override
+  void didComplete(T? result) {
+    _controller.hide(_context);
+    super.didComplete(result);
+  }
+
+  @override
+  void dispose() {
+    for (final OverlayEntry entry in _overlayEntries) {
+      entry.dispose();
+    }
+    _overlayEntries.clear();
+    super.dispose();
+  }
+}
+
+/// A route that displays widgets in a popup dialog [Window] with
+/// the help of the [Navigator].
+///
+/// If the size parameter is not provided when the dialog is created then
+/// the popup will attempt to render the contents of the popup once offscreen
+/// before building the [Window] with the correct size. In this case, you
+/// must ensure that the rendered widget has a [Size] that reflects the final
+/// size of the widget. To do this, you may want to check whether or not
+/// you have access to an [AutoSizedWindowCreatorContext] on your [BuildContext].
+/// If you do, you may want to do things like disabling animations.
+///
+/// This route is largely inspired by [TransitionRoute].
+///
+/// See also:
+///
+///  * [Route], which documents the meaning of the `T` generic type argument.
+class PopupWindowRoute<T> extends _WindowRoute<T> {
+  /// Creates a [Route] that creates a new popup [Window].
+  ///
+  /// [context] the build conext
+  /// [builder] the content that will end up in the dialog
+  /// [size] the [Size] of the dialog. If not provided, the dialog
+  ///        will be sized to fit the content from [builder].
+  /// [settings] settings for the [Route]
+  /// [anchorRect] the [Rect] to which this popup is anchored
+  /// [positioner] defines the constraints by which the popup is positioned
+  PopupWindowRoute({
+    required super.context,
+    required Widget Function(BuildContext, Animation<double>?) builder,
+    required Rect anchorRect,
+    required WindowPositioner positioner,
+    required NavigatorState navigator,
+    super.size,
+    super.settings,
+    super.onWindowOpened,
+    super.onWindowClosed,
+    AnimationStyle? popUpAnimationStyle,
+  })  : _builder = builder,
+        _anchorRect = anchorRect,
+        _positioner = positioner,
+        _popUpAnimationStyle = popUpAnimationStyle,
+        _navigator = navigator;
+
+  @override
+  WidgetBuilder get builder {
+    return (BuildContext context) {
+      return _builder(context, _animation);
+    };
+  }
+
+  final Widget Function(BuildContext, Animation<double>?) _builder;
+  final Rect _anchorRect;
+  final WindowPositioner _positioner;
+  final AnimationStyle? _popUpAnimationStyle;
+  final NavigatorState _navigator;
+
+  late final AnimationController _animationController;
+  late final Animation<double> _animation;
+
+  /// Handle to the performance mode request.
+  ///
+  /// When the route is animating, the performance mode is requested. It is then
+  /// disposed when the animation ends. Requesting [DartPerformanceMode.latency]
+  /// indicates to the engine that the transition is latency sensitive and to delay
+  /// non-essential work while this handle is active.
+  PerformanceModeRequestHandle? _performanceModeRequestHandle;
+
+  @override
+  Future<Window> _createWindow(
+      BuildContext context, WidgetBuilder builder, Size size, Window? parent) {
+    if (parent == null) {
+      throw Exception('Parent expected during PopupWindowRoute._createWindow');
+    }
+    return createPopup(
+        context: context,
+        parent: parent,
+        size: size,
+        anchorRect: _anchorRect,
+        positioner: _positioner,
+        builder: builder);
+  }
+
+  @override
+  void install() {
+    final Duration duration = _popUpAnimationStyle?.duration ?? _kMenuDuration;
+    _animationController = AnimationController(
+        duration: duration,
+        reverseDuration: duration,
+        debugLabel: 'PopupWindowRoute',
+        vsync: _navigator);
+    _animation = createAnimation()..addStatusListener(_handleStatusChanged);
+    super.install();
+  }
+
+  /// Called to create the animation that exposes the current progress of
+  /// the transition controlled by the animation controller created by
+  /// [createAnimationController()].
+  Animation<double> createAnimation() {
+    if (_popUpAnimationStyle != AnimationStyle.noAnimation) {
+      return CurvedAnimation(
+        parent: _animationController.view,
+        curve: _popUpAnimationStyle?.curve ?? Curves.linear,
+        reverseCurve: _popUpAnimationStyle?.reverseCurve ??
+            const Interval(0.0, _kMenuCloseIntervalEnd),
+      );
+    }
+
+    return _animationController.view;
+  }
+
+  @override
+  TickerFuture didPush() {
+    super.didPush();
+    return _animationController.forward();
+  }
+
+  void _handleStatusChanged(AnimationStatus status) {
+    switch (status) {
+      case AnimationStatus.completed:
+        _performanceModeRequestHandle?.dispose();
+        _performanceModeRequestHandle = null;
+      case AnimationStatus.forward:
+      case AnimationStatus.reverse:
+        _performanceModeRequestHandle ??= SchedulerBinding.instance
+            .requestPerformanceMode(DartPerformanceMode.latency);
+      case AnimationStatus.dismissed:
+        // We might still be an active route if a subclass is controlling the
+        // transition and hits the dismissed status. For example, the iOS
+        // back gesture drives this animation to the dismissed status before
+        // removing the route and disposing it.
+        if (!isActive) {
+          navigator!.finalizeRoute(this);
+          _performanceModeRequestHandle?.dispose();
+          _performanceModeRequestHandle = null;
+        }
+    }
+  }
+
+  @override
+  void dispose() {
+    _animation.removeStatusListener(_handleStatusChanged);
+    _animationController.dispose();
+    _performanceModeRequestHandle?.dispose();
+    _performanceModeRequestHandle = null;
+    super.dispose();
   }
 }


### PR DESCRIPTION
- Migrate the `Tooltip` widget to use multi window
- Added a tooltip application to the api_multiwindow examples


https://github.com/user-attachments/assets/e85d5ab6-93a0-4369-b2e7-0312d79c8d29


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
