### PR TITLE
feature: migrate showDialog to use multi-window

### DIFF
--- a/examples/api_multiwindow/lib/material/dialog/show_dialog.0.dart
+++ b/examples/api_multiwindow/lib/material/dialog/show_dialog.0.dart
@@ -1,0 +1,71 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [showDialog] in a multi-[Window] context
+
+void main() => runWidget(
+        MultiWindowApp(initialWindows: <Future<Window> Function(BuildContext)>[
+      (BuildContext context) => createRegular(
+          context: context,
+          size: const Size(800, 600),
+          builder: (BuildContext context) {
+            return const MaterialApp(home: DialogExample());
+          })
+    ]));
+
+class DialogExample extends StatelessWidget {
+  const DialogExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('showDialog Sample')),
+      body: Center(
+        child: OutlinedButton(
+          onPressed: () => _dialogBuilder(context),
+          child: const Text('Open Dialog'),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _dialogBuilder(BuildContext context) {
+    return showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Basic dialog title'),
+          content: const Text(
+            'A dialog is a type of modal window that\n'
+            'appears in front of app content to\n'
+            'provide critical information, or prompt\n'
+            'for a decision to be made.',
+          ),
+          actions: <Widget>[
+            TextButton(
+              style: TextButton.styleFrom(
+                textStyle: Theme.of(context).textTheme.labelLarge,
+              ),
+              child: const Text('Disable'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              style: TextButton.styleFrom(
+                textStyle: Theme.of(context).textTheme.labelLarge,
+              ),
+              child: const Text('Enable'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -30,6 +30,7 @@ import 'theme_data.dart';
 // late BuildContext context;
 
 const EdgeInsets _defaultInsetPadding = EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0);
+const EdgeInsets _defaultInsetPaddingMultiWindow = EdgeInsets.zero;
 
 /// A Material Design dialog.
 ///
@@ -232,7 +233,9 @@ class Dialog extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final DialogThemeData dialogTheme = DialogTheme.of(context);
     final EdgeInsets effectivePadding = MediaQuery.viewInsetsOf(context)
-      + (insetPadding ?? dialogTheme.insetPadding ?? _defaultInsetPadding);
+      + (insetPadding ?? dialogTheme.insetPadding ?? (MultiWindowAppContext.of(context) != null
+          ? _defaultInsetPaddingMultiWindow
+          : _defaultInsetPadding));
     final DialogThemeData defaults = theme.useMaterial3
       ? (_fullscreen ? _DialogFullscreenDefaultsM3(context) : _DialogDefaultsM3(context))
       : _DialogDefaultsM2(context);
@@ -1359,6 +1362,16 @@ Widget _buildMaterialDialogTransitions(BuildContext context, Animation<double> a
 /// The `routeSettings` argument is passed to [showGeneralDialog],
 /// see [RouteSettings] for details.
 ///
+/// If not null, the `onWindowOpened` argument will be called when the window
+/// is shown on screen. This only applies to a multi-window application.
+///
+/// If not null, the `onWindowClosed` argument will be called when the window
+/// is removed from the screen. This only applies to a multi-window application.
+///
+/// If set to true, `forceNoMultiWindow` will always make sure that the dialog
+/// will not be shown in a new window, regarldess of whether or not the feature
+/// is available in the application.
+///
 /// If not null, the `traversalEdgeBehavior` argument specifies the transfer of
 /// focus beyond the first and the last items of the dialog route. By default,
 /// [TraversalEdgeBehavior.closedLoop] is used, because it's typical for dialogs
@@ -1428,6 +1441,9 @@ Future<T?> showDialog<T>({
   RouteSettings? routeSettings,
   Offset? anchorPoint,
   TraversalEdgeBehavior? traversalEdgeBehavior,
+  void Function(Window)? onWindowOpened,
+  void Function(Window)? onWindowClosed,
+  bool forceNoMultiWindow = false
 }) {
   assert(_debugIsActive(context));
   assert(debugCheckHasMaterialLocalizations(context));
@@ -1440,21 +1456,33 @@ Future<T?> showDialog<T>({
     ).context,
   );
 
-  return Navigator.of(context, rootNavigator: useRootNavigator).push<T>(DialogRoute<T>(
-    context: context,
-    builder: builder,
-    barrierColor: barrierColor
-      ?? DialogTheme.of(context).barrierColor
-      ?? Theme.of(context).dialogTheme.barrierColor
-      ?? Colors.black54,
-    barrierDismissible: barrierDismissible,
-    barrierLabel: barrierLabel,
-    useSafeArea: useSafeArea,
-    settings: routeSettings,
-    themes: themes,
-    anchorPoint: anchorPoint,
-    traversalEdgeBehavior: traversalEdgeBehavior ?? TraversalEdgeBehavior.closedLoop,
-  ));
+  final MultiWindowAppContext? multiWindowAppContext =
+    MultiWindowAppContext.of(context);
+
+  if (multiWindowAppContext != null && !forceNoMultiWindow) {
+      return Navigator.of(context, rootNavigator: useRootNavigator)
+        .push<T>(ModalWindowRoute<T>(
+          context: context,
+          onWindowOpened: onWindowOpened,
+          onWindowClosed: onWindowClosed,
+          builder: builder));
+  } else {
+    return Navigator.of(context, rootNavigator: useRootNavigator).push<T>(DialogRoute<T>(
+      context: context,
+      builder: builder,
+      barrierColor: barrierColor
+        ?? DialogTheme.of(context).barrierColor
+        ?? Theme.of(context).dialogTheme.barrierColor
+        ?? Colors.black54,
+      barrierDismissible: barrierDismissible,
+      barrierLabel: barrierLabel,
+      useSafeArea: useSafeArea,
+      settings: routeSettings,
+      themes: themes,
+      anchorPoint: anchorPoint,
+      traversalEdgeBehavior: traversalEdgeBehavior ?? TraversalEdgeBehavior.closedLoop,
+    ));
+  }
 }
 
 /// Displays either a Material or Cupertino dialog depending on platform.

--- a/packages/flutter/lib/src/widgets/window.dart
+++ b/packages/flutter/lib/src/widgets/window.dart
@@ -1252,6 +1252,42 @@ abstract class _WindowRoute<T> extends Route<T> {
   }
 }
 
+/// A route that displays widgets in a modal dialog [Window] with
+/// the help of the [Navigator].
+///
+/// See also:
+///
+///  * [Route], which documents the meaning of the `T` generic type argument.
+class ModalWindowRoute<T> extends _WindowRoute<T> {
+  /// Creates a [Route] that creates a new modal dialog [Window].
+  ///
+  /// [context] the build conext
+  /// [builder] the content that will end up in the dialog
+  /// [size] the [Size] of the dialog. If not provided, the dialog
+  ///        will be sized to fit the content from [builder].
+  /// [settings] settings for the [Route]
+  ModalWindowRoute(
+      {required super.context,
+      required WidgetBuilder builder,
+      super.size,
+      super.settings,
+      super.onWindowOpened,
+      super.onWindowClosed})
+      : _builder = builder;
+
+  final WidgetBuilder _builder;
+
+  @override
+  WidgetBuilder get builder => _builder;
+
+  @override
+  Future<Window> _createWindow(
+      BuildContext context, WidgetBuilder builder, Size size, Window? parent) {
+    return createDialog(
+        context: context, parent: parent, size: size, builder: builder);
+  }
+}
+
 /// A route that displays widgets in a popup dialog [Window] with
 /// the help of the [Navigator].
 ///


### PR DESCRIPTION
- Migrate `showDialog` to use multi-window
- Add a showDialog application to the api_multiwindow examples


https://github.com/user-attachments/assets/8362c945-59e6-4deb-aecd-846f2ba5512b


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
