### PR TITLE
Refactor method channel for regular windows

### DIFF
--- a/engine/src/flutter/shell/platform/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/common/BUILD.gn
@@ -148,6 +148,8 @@ source_set("common_cpp_core") {
   sources = [ "path_utils.cc" ]
 
   public_configs = [ "//flutter:config" ]
+
+  deps = [ "//flutter/fml:fml" ]
 }
 
 if (enable_unittests) {

--- a/engine/src/flutter/shell/platform/common/windowing.h
+++ b/engine/src/flutter/shell/platform/common/windowing.h
@@ -7,7 +7,7 @@
 
 #include <optional>
 
-#include "flutter/fml/mapping.h"
+#include "flutter/fml/logging.h"
 #include "geometry.h"
 
 namespace flutter {

--- a/engine/src/flutter/shell/platform/common/windowing.h
+++ b/engine/src/flutter/shell/platform/common/windowing.h
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "flutter/fml/mapping.h"
 #include "geometry.h"
 
 namespace flutter {
@@ -17,48 +18,51 @@ using FlutterViewId = int64_t;
 // Types of windows.
 enum class WindowArchetype {
   // Regular top-level window.
-  regular,
+  kRegular,
 };
 
 // Possible states a window can be in.
 enum class WindowState {
   // Normal state, neither maximized, nor minimized.
-  restored,
+  kRestored,
   // Maximized, occupying the full screen but still showing the system UI.
-  maximized,
+  kMaximized,
   // Minimized and not visible on the screen.
-  minimized,
+  kMinimized,
 };
 
-// Converts a |flutter::WindowState| to its corresponding string representation.
+// Converts a |flutter::WindowState| to the string representation of
+// |WindowState| as defined in the framework.
 inline std::string WindowStateToString(WindowState state) {
   switch (state) {
-    case WindowState::restored:
+    case WindowState::kRestored:
       return "WindowState.restored";
-    case WindowState::maximized:
+    case WindowState::kMaximized:
       return "WindowState.maximized";
-    case WindowState::minimized:
+    case WindowState::kMinimized:
       return "WindowState.minimized";
+    default:
+      FML_UNREACHABLE();
   }
-  return {};
 }
 
-// Converts a string to a |flutter::WindowState|. Returns std::nullopt if
+// Converts the string representation of |WindowState| defined in the framework
+// to a |flutter::WindowState|. Returns std::nullopt if the given string is
 // invalid.
 inline std::optional<WindowState> StringToWindowState(std::string_view str) {
   if (str == "WindowState.restored")
-    return WindowState::restored;
+    return WindowState::kRestored;
   if (str == "WindowState.maximized")
-    return WindowState::maximized;
+    return WindowState::kMaximized;
   if (str == "WindowState.minimized")
-    return WindowState::minimized;
+    return WindowState::kMinimized;
   return std::nullopt;
 }
 
 // Settings used for creating a Flutter window.
 struct WindowCreationSettings {
   // Type of the window.
-  WindowArchetype archetype = WindowArchetype::regular;
+  WindowArchetype archetype = WindowArchetype::kRegular;
   // Requested size of the window's client area, in logical coordinates.
   Size size;
   // Minimum size of the window's client area, in logical coordinates.
@@ -76,7 +80,7 @@ struct WindowMetadata {
   // The ID of the view used for this window, which is unique to each window.
   FlutterViewId view_id = 0;
   // The type of the window.
-  WindowArchetype archetype = WindowArchetype::regular;
+  WindowArchetype archetype = WindowArchetype::kRegular;
   // Size of the created window, in logical coordinates.
   Size size;
   // The ID of the view used by the parent window. If not set, the window is

--- a/engine/src/flutter/shell/platform/common/windowing.h
+++ b/engine/src/flutter/shell/platform/common/windowing.h
@@ -7,66 +7,68 @@
 
 #include <optional>
 
+#include "geometry.h"
+
 namespace flutter {
 
 // A unique identifier for a view.
 using FlutterViewId = int64_t;
 
-// A point in 2D space for window positioning using integer coordinates.
-struct WindowPoint {
-  int x = 0;
-  int y = 0;
-
-  friend WindowPoint operator+(WindowPoint const& lhs, WindowPoint const& rhs) {
-    return {lhs.x + rhs.x, lhs.y + rhs.y};
-  }
-
-  friend WindowPoint operator-(WindowPoint const& lhs, WindowPoint const& rhs) {
-    return {lhs.x - rhs.x, lhs.y - rhs.y};
-  }
-
-  friend bool operator==(WindowPoint const& lhs, WindowPoint const& rhs) {
-    return lhs.x == rhs.x && lhs.y == rhs.y;
-  }
-};
-
-// A 2D size using integer dimensions.
-struct WindowSize {
-  int width = 0;
-  int height = 0;
-
-  explicit operator WindowPoint() const { return {width, height}; }
-
-  friend bool operator==(WindowSize const& lhs, WindowSize const& rhs) {
-    return lhs.width == rhs.width && lhs.height == rhs.height;
-  }
-};
-
-// A rectangular area defined by a top-left point and size.
-struct WindowRectangle {
-  WindowPoint top_left;
-  WindowSize size;
-
-  // Checks if this rectangle fully contains |rect|.
-  // Note: An empty rectangle can still contain other empty rectangles,
-  // which are treated as points or lines of thickness zero
-  bool contains(WindowRectangle const& rect) const {
-    return rect.top_left.x >= top_left.x &&
-           rect.top_left.x + rect.size.width <= top_left.x + size.width &&
-           rect.top_left.y >= top_left.y &&
-           rect.top_left.y + rect.size.height <= top_left.y + size.height;
-  }
-
-  friend bool operator==(WindowRectangle const& lhs,
-                         WindowRectangle const& rhs) {
-    return lhs.top_left == rhs.top_left && lhs.size == rhs.size;
-  }
-};
-
 // Types of windows.
 enum class WindowArchetype {
   // Regular top-level window.
   regular,
+};
+
+// Possible states a window can be in.
+enum class WindowState {
+  // Normal state, neither maximized, nor minimized.
+  restored,
+  // Maximized, occupying the full screen but still showing the system UI.
+  maximized,
+  // Minimized and not visible on the screen.
+  minimized,
+};
+
+// Converts a |flutter::WindowState| to its corresponding string representation.
+inline std::string WindowStateToString(WindowState state) {
+  switch (state) {
+    case WindowState::restored:
+      return "WindowState.restored";
+    case WindowState::maximized:
+      return "WindowState.maximized";
+    case WindowState::minimized:
+      return "WindowState.minimized";
+  }
+  return {};
+}
+
+// Converts a string to a |flutter::WindowState|. Returns std::nullopt if
+// invalid.
+inline std::optional<WindowState> StringToWindowState(std::string_view str) {
+  if (str == "WindowState.restored")
+    return WindowState::restored;
+  if (str == "WindowState.maximized")
+    return WindowState::maximized;
+  if (str == "WindowState.minimized")
+    return WindowState::minimized;
+  return std::nullopt;
+}
+
+// Settings used for creating a Flutter window.
+struct WindowCreationSettings {
+  // Type of the window.
+  WindowArchetype archetype = WindowArchetype::regular;
+  // Requested size of the window's client area, in logical coordinates.
+  Size size;
+  // Minimum size of the window's client area, in logical coordinates.
+  std::optional<Size> min_size;
+  // Maximum size of the window's client area, in logical coordinates.
+  std::optional<Size> max_size;
+  // Window title.
+  std::optional<std::string> title;
+  // Initial state of the window.
+  std::optional<WindowState> state;
 };
 
 // Window metadata returned as the result of creating a Flutter window.
@@ -76,10 +78,12 @@ struct WindowMetadata {
   // The type of the window.
   WindowArchetype archetype = WindowArchetype::regular;
   // Size of the created window, in logical coordinates.
-  WindowSize size;
+  Size size;
   // The ID of the view used by the parent window. If not set, the window is
   // assumed a top-level window.
   std::optional<FlutterViewId> parent_id;
+  // The initial state of the window, or std::nullopt if not a regular window.
+  std::optional<WindowState> state;
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
@@ -131,11 +131,13 @@ std::string GetLastErrorAsString() {
 }
 
 // Calculates the required window size, in physical coordinates, to
-// accommodate the given |client_size|, in logical coordinates, constrained to
-// |min_size| and |max_size|, for a window with the specified |window_style| and
-// |extended_window_style|. The result accounts for window borders, non-client
-// areas, and the drop-shadow area. On error, return std::nullopt and log the
-// error.
+// accommodate the given |client_size|, in logical coordinates, constrained by
+// optional |min_size| and |max_size|, for a window with the specified
+// |window_style| and |extended_window_style|. If |owner_hwnd| is not null, the
+// DPI of the display with the largest area of intersection with |owner_hwnd| is
+// used for the calculation; otherwise, the primary display's DPI is used. The
+// resulting size includes window borders, non-client areas, and drop shadows.
+// On error, returns std::nullopt and logs an error message.
 std::optional<flutter::Size> GetWindowSizeForClientSize(
     flutter::Size const& client_size,
     std::optional<flutter::Size> min_size,
@@ -210,7 +212,7 @@ bool IsClassRegistered(LPCWSTR class_name) {
          0;
 }
 
-// Convert std::string to std::wstring
+// Convert std::string to std::wstring.
 std::wstring StringToWstring(std::string const& str) {
   if (str.empty()) {
     return {};
@@ -280,7 +282,7 @@ FlutterHostWindow::FlutterHostWindow(FlutterHostWindowController* controller,
       FML_UNREACHABLE();
   }
 
-  // Validate size constraints
+  // Validate size constraints.
   min_size_ = settings.min_size;
   max_size_ = settings.max_size;
   if (min_size_ && max_size_) {
@@ -293,8 +295,8 @@ FlutterHostWindow::FlutterHostWindow(FlutterHostWindowController* controller,
 
   // Calculate the screen space window rectangle for the new window.
   // Default positioning values (CW_USEDEFAULT) are used
-  // if the window has no owner or positioner.
-  Rect initial_window_rect = [&]() -> Rect {
+  // if the window has no owner.
+  Rect const initial_window_rect = [&]() -> Rect {
     std::optional<Size> const window_size = GetWindowSizeForClientSize(
         settings.size, min_size_, max_size_, window_style,
         extended_window_style, nullptr);
@@ -556,7 +558,7 @@ LRESULT FlutterHostWindow::HandleMessage(HWND hwnd,
 
     case WM_SIZE: {
       if (child_content_ != nullptr) {
-        // Resize and reposition the child content window
+        // Resize and reposition the child content window.
         RECT client_rect;
         GetClientRect(hwnd, &client_rect);
         MoveWindow(child_content_, client_rect.left, client_rect.top,

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
@@ -146,9 +146,9 @@ std::optional<flutter::Size> GetWindowSizeForClientSize(
   UINT const dpi = flutter::GetDpiForHWND(owner_hwnd);
   double const scale_factor =
       static_cast<double>(dpi) / USER_DEFAULT_SCREEN_DPI;
-  RECT rect = {};
-  rect.right = static_cast<LONG>(client_size.width() * scale_factor);
-  rect.bottom = static_cast<LONG>(client_size.height() * scale_factor);
+  RECT rect = {
+      .right = static_cast<LONG>(client_size.width() * scale_factor),
+      .bottom = static_cast<LONG>(client_size.height() * scale_factor)};
 
   HMODULE const user32_raw = LoadLibraryA("User32.dll");
   auto free_user32_module = [](HMODULE module) { FreeLibrary(module); };
@@ -211,7 +211,7 @@ bool IsClassRegistered(LPCWSTR class_name) {
 }
 
 // Convert std::string to std::wstring
-std::wstring StringToWstring(const std::string& str) {
+std::wstring StringToWstring(std::string const& str) {
   if (str.empty()) {
     return {};
   }
@@ -273,7 +273,7 @@ FlutterHostWindow::FlutterHostWindow(FlutterHostWindowController* controller,
   DWORD window_style = 0;
   DWORD extended_window_style = 0;
   switch (archetype_) {
-    case WindowArchetype::regular:
+    case WindowArchetype::kRegular:
       window_style |= WS_OVERLAPPEDWINDOW;
       break;
     default:
@@ -395,7 +395,7 @@ FlutterHostWindow::FlutterHostWindow(FlutterHostWindowController* controller,
 
   SetChildContent(view_controller_->view()->GetWindowHandle());
 
-  state_ = settings.state.value_or(WindowState::restored);
+  state_ = settings.state.value_or(WindowState::kRestored);
 
   // TODO(loicsharma): Hide the window until the first frame is rendered.
   // Single window apps use the engine's next frame callback to show the
@@ -403,15 +403,15 @@ FlutterHostWindow::FlutterHostWindow(FlutterHostWindowController* controller,
   // multiple next frame callbacks. If multiple windows are created, only the
   // last one will be shown.
   UINT const cmd_show = [&]() {
-    if (archetype_ == WindowArchetype::regular) {
+    if (archetype_ == WindowArchetype::kRegular) {
       switch (state_) {
-        case WindowState::restored:
+        case WindowState::kRestored:
           return SW_SHOWNORMAL;
           break;
-        case WindowState::maximized:
+        case WindowState::kMaximized:
           return SW_SHOWMAXIMIZED;
           break;
-        case WindowState::minimized:
+        case WindowState::kMinimized:
           return SW_SHOWMINIMIZED;
           break;
         default:

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
@@ -15,6 +15,16 @@ namespace {
 
 constexpr wchar_t kWindowClassName[] = L"FLUTTER_HOST_WINDOW";
 
+// Clamps |size| to the size of the virtual screen. Both the parameter and
+// return size are in physical coordinates.
+flutter::Size ClampToVirtualScreen(flutter::Size size) {
+  double const virtual_screen_width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+  double const virtual_screen_height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+  return flutter::Size(std::clamp(size.width(), 0.0, virtual_screen_width),
+                       std::clamp(size.height(), 0.0, virtual_screen_height));
+}
+
 // Dynamically loads the |EnableNonClientDpiScaling| from the User32 module
 // so that the non-client area automatically responds to changes in DPI.
 // This API is only needed for PerMonitor V1 awareness mode.
@@ -121,56 +131,75 @@ std::string GetLastErrorAsString() {
 }
 
 // Calculates the required window size, in physical coordinates, to
-// accommodate the given |client_size|, in logical coordinates, for a window
-// with the specified |window_style| and |extended_window_style|. The result
-// accounts for window borders, non-client areas, and the drop-shadow area.
-flutter::WindowSize GetWindowSizeForClientSize(
-    flutter::WindowSize const& client_size,
+// accommodate the given |client_size|, in logical coordinates, constrained to
+// |min_size| and |max_size|, for a window with the specified |window_style| and
+// |extended_window_style|. The result accounts for window borders, non-client
+// areas, and the drop-shadow area. On error, return std::nullopt and log the
+// error.
+std::optional<flutter::Size> GetWindowSizeForClientSize(
+    flutter::Size const& client_size,
+    std::optional<flutter::Size> min_size,
+    std::optional<flutter::Size> max_size,
     DWORD window_style,
     DWORD extended_window_style,
     HWND owner_hwnd) {
   UINT const dpi = flutter::GetDpiForHWND(owner_hwnd);
   double const scale_factor =
       static_cast<double>(dpi) / USER_DEFAULT_SCREEN_DPI;
-  RECT rect = {.left = 0,
-               .top = 0,
-               .right = static_cast<LONG>(client_size.width * scale_factor),
-               .bottom = static_cast<LONG>(client_size.height * scale_factor)};
+  RECT rect = {};
+  rect.right = static_cast<LONG>(client_size.width() * scale_factor);
+  rect.bottom = static_cast<LONG>(client_size.height() * scale_factor);
 
-  HMODULE const user32_module = LoadLibraryA("User32.dll");
-  if (user32_module) {
-    using AdjustWindowRectExForDpi = BOOL __stdcall(
-        LPRECT lpRect, DWORD dwStyle, BOOL bMenu, DWORD dwExStyle, UINT dpi);
-
-    auto* const adjust_window_rect_ext_for_dpi =
-        reinterpret_cast<AdjustWindowRectExForDpi*>(
-            GetProcAddress(user32_module, "AdjustWindowRectExForDpi"));
-    if (adjust_window_rect_ext_for_dpi) {
-      if (adjust_window_rect_ext_for_dpi(&rect, window_style, FALSE,
-                                         extended_window_style, dpi)) {
-        FreeLibrary(user32_module);
-        return {static_cast<int>(rect.right - rect.left),
-                static_cast<int>(rect.bottom - rect.top)};
-      } else {
-        FML_LOG(WARNING) << "Failed to run AdjustWindowRectExForDpi: "
-                         << GetLastErrorAsString();
-      }
-    } else {
-      FML_LOG(WARNING)
-          << "Failed to retrieve AdjustWindowRectExForDpi address from "
-             "User32.dll.";
-    }
-    FreeLibrary(user32_module);
-  } else {
-    FML_LOG(WARNING) << "Failed to load User32.dll.\n";
+  HMODULE const user32_raw = LoadLibraryA("User32.dll");
+  auto free_user32_module = [](HMODULE module) { FreeLibrary(module); };
+  std::unique_ptr<std::remove_pointer_t<HMODULE>, decltype(free_user32_module)>
+      user32_module(user32_raw, free_user32_module);
+  if (!user32_module) {
+    FML_LOG(ERROR) << "Failed to load User32.dll.\n";
+    return std::nullopt;
   }
 
-  if (!AdjustWindowRectEx(&rect, window_style, FALSE, extended_window_style)) {
-    FML_LOG(WARNING) << "Failed to run AdjustWindowRectEx: "
-                     << GetLastErrorAsString();
+  using AdjustWindowRectExForDpi = BOOL __stdcall(
+      LPRECT lpRect, DWORD dwStyle, BOOL bMenu, DWORD dwExStyle, UINT dpi);
+  auto* const adjust_window_rect_ext_for_dpi =
+      reinterpret_cast<AdjustWindowRectExForDpi*>(
+          GetProcAddress(user32_raw, "AdjustWindowRectExForDpi"));
+  if (!adjust_window_rect_ext_for_dpi) {
+    FML_LOG(ERROR) << "Failed to retrieve AdjustWindowRectExForDpi address "
+                      "from User32.dll.";
+    return std::nullopt;
   }
-  return {static_cast<int>(rect.right - rect.left),
-          static_cast<int>(rect.bottom - rect.top)};
+
+  if (!adjust_window_rect_ext_for_dpi(&rect, window_style, FALSE,
+                                      extended_window_style, dpi)) {
+    FML_LOG(ERROR) << "Failed to run AdjustWindowRectExForDpi: "
+                   << GetLastErrorAsString();
+    return std::nullopt;
+  }
+
+  double width = static_cast<double>(rect.right - rect.left);
+  double height = static_cast<double>(rect.bottom - rect.top);
+
+  // Apply size constraints
+  double const non_client_width = width - (client_size.width() * scale_factor);
+  double const non_client_height =
+      height - (client_size.height() * scale_factor);
+  if (min_size) {
+    flutter::Size min_physical_size = ClampToVirtualScreen(
+        flutter::Size(min_size->width() * scale_factor + non_client_width,
+                      min_size->height() * scale_factor + non_client_height));
+    width = std::max(width, min_physical_size.width());
+    height = std::max(height, min_physical_size.height());
+  }
+  if (max_size) {
+    flutter::Size max_physical_size = ClampToVirtualScreen(
+        flutter::Size(max_size->width() * scale_factor + non_client_width,
+                      max_size->height() * scale_factor + non_client_height));
+    width = std::min(width, max_physical_size.width());
+    height = std::min(height, max_physical_size.height());
+  }
+
+  return flutter::Size{width, height};
 }
 
 // Checks whether the window class of name |class_name| is registered for the
@@ -179,6 +208,23 @@ bool IsClassRegistered(LPCWSTR class_name) {
   WNDCLASSEX window_class = {};
   return GetClassInfoEx(GetModuleHandle(nullptr), class_name, &window_class) !=
          0;
+}
+
+// Convert std::string to std::wstring
+std::wstring StringToWstring(const std::string& str) {
+  if (str.empty()) {
+    return {};
+  }
+  if (int buffer_size =
+          MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0)) {
+    std::wstring wide_str(buffer_size, L'\0');
+    if (MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wide_str[0],
+                            buffer_size)) {
+      wide_str.pop_back();
+      return wide_str;
+    }
+  }
+  return {};
 }
 
 // Window attribute that enables dark mode window decorations.
@@ -219,16 +265,14 @@ void UpdateTheme(HWND window) {
 namespace flutter {
 
 FlutterHostWindow::FlutterHostWindow(FlutterHostWindowController* controller,
-                                     std::wstring const& title,
-                                     WindowSize const& preferred_client_size,
-                                     WindowArchetype archetype)
+                                     WindowCreationSettings const& settings)
     : window_controller_(controller) {
-  archetype_ = archetype;
+  archetype_ = settings.archetype;
 
   // Check preconditions and set window styles based on window type.
   DWORD window_style = 0;
   DWORD extended_window_style = 0;
-  switch (archetype) {
+  switch (archetype_) {
     case WindowArchetype::regular:
       window_style |= WS_OVERLAPPEDWINDOW;
       break;
@@ -236,13 +280,26 @@ FlutterHostWindow::FlutterHostWindow(FlutterHostWindowController* controller,
       FML_UNREACHABLE();
   }
 
+  // Validate size constraints
+  min_size_ = settings.min_size;
+  max_size_ = settings.max_size;
+  if (min_size_ && max_size_) {
+    if (min_size_->width() > max_size_->width() ||
+        min_size_->height() > max_size_->height()) {
+      FML_LOG(ERROR) << "Invalid size constraints.";
+      return;
+    }
+  }
+
   // Calculate the screen space window rectangle for the new window.
   // Default positioning values (CW_USEDEFAULT) are used
   // if the window has no owner or positioner.
-  WindowRectangle const window_rect = [&]() -> WindowRectangle {
-    WindowSize const window_size = GetWindowSizeForClientSize(
-        preferred_client_size, window_style, extended_window_style, nullptr);
-    return {{CW_USEDEFAULT, CW_USEDEFAULT}, window_size};
+  Rect initial_window_rect = [&]() -> Rect {
+    std::optional<Size> const window_size = GetWindowSizeForClientSize(
+        settings.size, min_size_, max_size_, window_style,
+        extended_window_style, nullptr);
+    return {{CW_USEDEFAULT, CW_USEDEFAULT},
+            window_size ? *window_size : Size{CW_USEDEFAULT, CW_USEDEFAULT}};
   }();
 
   // Register the window class.
@@ -264,15 +321,17 @@ FlutterHostWindow::FlutterHostWindow(FlutterHostWindowController* controller,
     if (!RegisterClassEx(&window_class)) {
       FML_LOG(ERROR) << "Cannot register window class " << kWindowClassName
                      << ": " << GetLastErrorAsString();
+      return;
     }
   }
 
   // Create the native window.
-  HWND hwnd = CreateWindowEx(extended_window_style, kWindowClassName,
-                             title.c_str(), window_style,
-                             window_rect.top_left.x, window_rect.top_left.y,
-                             window_rect.size.width, window_rect.size.height,
-                             nullptr, nullptr, GetModuleHandle(nullptr), this);
+  HWND hwnd = CreateWindowEx(
+      extended_window_style, kWindowClassName,
+      StringToWstring(settings.title.value_or("")).c_str(), window_style,
+      initial_window_rect.left(), initial_window_rect.top(),
+      initial_window_rect.width(), initial_window_rect.height(), nullptr,
+      nullptr, GetModuleHandle(nullptr), this);
 
   if (!hwnd) {
     FML_LOG(ERROR) << "Cannot create window: " << GetLastErrorAsString();
@@ -283,15 +342,15 @@ FlutterHostWindow::FlutterHostWindow(FlutterHostWindowController* controller,
   // of the window frame, not the window rectangle (which includes the
   // drop-shadow). This adjustment must be done post-creation since the frame
   // rectangle is only available after the window has been created.
-  RECT frame_rc;
-  DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &frame_rc,
-                        sizeof(frame_rc));
-  RECT window_rc;
-  GetWindowRect(hwnd, &window_rc);
-  LONG const left_dropshadow_width = frame_rc.left - window_rc.left;
-  LONG const top_dropshadow_height = window_rc.top - frame_rc.top;
-  SetWindowPos(hwnd, nullptr, window_rc.left - left_dropshadow_width,
-               window_rc.top - top_dropshadow_height, 0, 0,
+  RECT frame_rect;
+  DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &frame_rect,
+                        sizeof(frame_rect));
+  RECT window_rect;
+  GetWindowRect(hwnd, &window_rect);
+  LONG const left_dropshadow_width = frame_rect.left - window_rect.left;
+  LONG const top_dropshadow_height = window_rect.top - frame_rect.top;
+  SetWindowPos(hwnd, nullptr, window_rect.left - left_dropshadow_width,
+               window_rect.top - top_dropshadow_height, 0, 0,
                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 
   // Set up the view.
@@ -336,12 +395,32 @@ FlutterHostWindow::FlutterHostWindow(FlutterHostWindowController* controller,
 
   SetChildContent(view_controller_->view()->GetWindowHandle());
 
+  state_ = settings.state.value_or(WindowState::restored);
+
   // TODO(loicsharma): Hide the window until the first frame is rendered.
-  // Single window apps use the engine's next frame callback to show the window.
-  // This doesn't work for multi window apps as the engine cannot have multiple
-  // next frame callbacks. If multiple windows are created, only the last one
-  // will be shown.
-  ShowWindow(hwnd, SW_SHOW);
+  // Single window apps use the engine's next frame callback to show the
+  // window. This doesn't work for multi window apps as the engine cannot have
+  // multiple next frame callbacks. If multiple windows are created, only the
+  // last one will be shown.
+  UINT const cmd_show = [&]() {
+    if (archetype_ == WindowArchetype::regular) {
+      switch (state_) {
+        case WindowState::restored:
+          return SW_SHOWNORMAL;
+          break;
+        case WindowState::maximized:
+          return SW_SHOWMAXIMIZED;
+          break;
+        case WindowState::minimized:
+          return SW_SHOWMINIMIZED;
+          break;
+        default:
+          FML_UNREACHABLE();
+      }
+    }
+    return SW_SHOWNORMAL;
+  }();
+  ShowWindow(hwnd, cmd_show);
 
   window_handle_ = hwnd;
 }
@@ -370,12 +449,13 @@ WindowArchetype FlutterHostWindow::GetArchetype() const {
   return archetype_;
 }
 
-std::optional<FlutterViewId> FlutterHostWindow::GetFlutterViewId() const {
-  if (!view_controller_ || !view_controller_->view()) {
-    return std::nullopt;
-  }
+FlutterViewId FlutterHostWindow::GetFlutterViewId() const {
   return view_controller_->view()->view_id();
 };
+
+WindowState FlutterHostWindow::GetState() const {
+  return state_;
+}
 
 HWND FlutterHostWindow::GetWindowHandle() const {
   return window_handle_;
@@ -437,6 +517,40 @@ LRESULT FlutterHostWindow::HandleMessage(HWND hwnd,
       SetWindowPos(hwnd, nullptr, new_scaled_window_rect->left,
                    new_scaled_window_rect->top, width, height,
                    SWP_NOZORDER | SWP_NOACTIVATE);
+      return 0;
+    }
+
+    case WM_GETMINMAXINFO: {
+      RECT window_rect;
+      GetWindowRect(hwnd, &window_rect);
+      RECT client_rect;
+      GetClientRect(hwnd, &client_rect);
+      LONG const non_client_width = (window_rect.right - window_rect.left) -
+                                    (client_rect.right - client_rect.left);
+      LONG const non_client_height = (window_rect.bottom - window_rect.top) -
+                                     (client_rect.bottom - client_rect.top);
+
+      UINT const dpi = flutter::GetDpiForHWND(hwnd);
+      double const scale_factor =
+          static_cast<double>(dpi) / USER_DEFAULT_SCREEN_DPI;
+
+      MINMAXINFO* info = reinterpret_cast<MINMAXINFO*>(lparam);
+      if (min_size_) {
+        Size const min_physical_size = ClampToVirtualScreen(
+            Size(min_size_->width() * scale_factor + non_client_width,
+                 min_size_->height() * scale_factor + non_client_height));
+
+        info->ptMinTrackSize.x = min_physical_size.width();
+        info->ptMinTrackSize.y = min_physical_size.height();
+      }
+      if (max_size_) {
+        Size const max_physical_size = ClampToVirtualScreen(
+            Size(max_size_->width() * scale_factor + non_client_width,
+                 max_size_->height() * scale_factor + non_client_height));
+
+        info->ptMaxTrackSize.x = max_physical_size.width();
+        info->ptMaxTrackSize.y = max_physical_size.height();
+      }
       return 0;
     }
 

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.h
@@ -79,7 +79,7 @@ class FlutterHostWindow {
   std::unique_ptr<FlutterWindowsViewController> view_controller_;
 
   // The window archetype.
-  WindowArchetype archetype_ = WindowArchetype::regular;
+  WindowArchetype archetype_ = WindowArchetype::kRegular;
 
   // Indicates if closing this window will quit the application.
   bool quit_on_close_ = false;
@@ -97,7 +97,7 @@ class FlutterHostWindow {
   std::optional<Size> max_size_;
 
   // The window state.
-  WindowState state_ = WindowState::restored;
+  WindowState state_ = WindowState::kRestored;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterHostWindow);
 };

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.h
@@ -23,15 +23,11 @@ class FlutterWindowsViewController;
 class FlutterHostWindow {
  public:
   // Creates a native Win32 window with a child view confined to its client
-  // area. |controller| manages the window. |title| is the window title.
-  // |preferred_client_size| is the preferred size of the client rectangle in
-  // logical coordinates. The window style is defined by |archetype|.
-  // On success, a valid window handle can be retrieved via
+  // area. |controller| is a pointer to the controller that manages the
+  // |FlutterHostWindow|. On success, a valid window handle can be retrieved via
   // |FlutterHostWindow::GetWindowHandle|.
   FlutterHostWindow(FlutterHostWindowController* controller,
-                    std::wstring const& title,
-                    WindowSize const& preferred_client_size,
-                    WindowArchetype archetype);
+                    WindowCreationSettings const& settings);
   virtual ~FlutterHostWindow();
 
   // Returns the instance pointer for |hwnd| or nulllptr if invalid.
@@ -40,8 +36,11 @@ class FlutterHostWindow {
   // Returns the window archetype.
   WindowArchetype GetArchetype() const;
 
-  // Returns the hosted Flutter view's ID or std::nullopt if not created.
-  std::optional<FlutterViewId> GetFlutterViewId() const;
+  // Returns the hosted Flutter view's ID.
+  FlutterViewId GetFlutterViewId() const;
+
+  // Returns the current window state.
+  WindowState GetState() const;
 
   // Returns the backing window handle, or nullptr if the native window is not
   // created or has already been destroyed.
@@ -90,6 +89,15 @@ class FlutterHostWindow {
 
   // Backing handle for the hosted view window.
   HWND child_content_ = nullptr;
+
+  // The minimum size of the window's client area, if defined.
+  std::optional<Size> min_size_;
+
+  // The maximum size of the window's client area, if defined.
+  std::optional<Size> max_size_;
+
+  // The window state.
+  WindowState state_ = WindowState::restored;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterHostWindow);
 };

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
@@ -112,10 +112,11 @@ LRESULT FlutterHostWindowController::HandleMessage(HWND hwnd,
           });
       if (it != windows_.end()) {
         auto& [view_id, window] = *it;
-        if (window->archetype_ == WindowArchetype::regular) {
-          window->state_ = (wparam == SIZE_MAXIMIZED)   ? WindowState::maximized
-                           : (wparam == SIZE_MINIMIZED) ? WindowState::minimized
-                                                        : WindowState::restored;
+        if (window->archetype_ == WindowArchetype::kRegular) {
+          window->state_ = (wparam == SIZE_MAXIMIZED) ? WindowState::kMaximized
+                           : (wparam == SIZE_MINIMIZED)
+                               ? WindowState::kMinimized
+                               : WindowState::kRestored;
         }
         SendOnWindowChanged(view_id, GetWindowSize(view_id), std::nullopt);
       }

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
@@ -51,17 +51,17 @@ std::optional<WindowMetadata> FlutterHostWindowController::CreateHostWindow(
   WindowState const state = window->GetState();
   windows_[view_id] = std::move(window);
 
-  WindowMetadata result = {.view_id = view_id,
-                           .archetype = settings.archetype,
-                           .size = GetWindowSize(view_id),
-                           .parent_id = std::nullopt,
-                           .state = state};
+  WindowMetadata const result = {.view_id = view_id,
+                                 .archetype = settings.archetype,
+                                 .size = GetWindowSize(view_id),
+                                 .parent_id = std::nullopt,
+                                 .state = state};
 
   return result;
 }
 
 bool FlutterHostWindowController::DestroyHostWindow(FlutterViewId view_id) {
-  if (auto it = windows_.find(view_id); it != windows_.end()) {
+  if (auto const it = windows_.find(view_id); it != windows_.end()) {
     FlutterHostWindow* const window = it->second.get();
     HWND const window_handle = window->GetWindowHandle();
 
@@ -75,7 +75,7 @@ bool FlutterHostWindowController::DestroyHostWindow(FlutterViewId view_id) {
 
 FlutterHostWindow* FlutterHostWindowController::GetHostWindow(
     FlutterViewId view_id) const {
-  if (auto it = windows_.find(view_id); it != windows_.end()) {
+  if (auto const it = windows_.find(view_id); it != windows_.end()) {
     return it->second.get();
   }
   return nullptr;
@@ -146,7 +146,7 @@ void FlutterHostWindowController::DestroyAllWindows() {
     // Destroy windows in reverse order of creation.
     for (auto it = std::prev(windows_.end());
          it != std::prev(windows_.begin());) {
-      auto current = it--;
+      auto const current = it--;
       auto const& [view_id, window] = *current;
       if (window->GetWindowHandle()) {
         DestroyHostWindow(view_id);

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.h
@@ -29,17 +29,10 @@ class FlutterHostWindowController {
   // Flutter view that is displayed in the client area of the
   // |FlutterHostWindow|.
   //
-  // |title| is the window title string. |preferred_size| is the preferred size
-  // of the client rectangle, i.e., the size expected for the child view, in
-  // logical coordinates. The actual size may differ. The window style is
-  // determined by |archetype|.
-  //
   // Returns a |WindowMetadata| with the metadata of the window just created, or
   // std::nullopt if the window could not be created.
   virtual std::optional<WindowMetadata> CreateHostWindow(
-      std::wstring const& title,
-      WindowSize const& preferred_size,
-      WindowArchetype archetype);
+      WindowCreationSettings const& settings);
 
   // Destroys the window that hosts the view with ID |view_id|.
   //
@@ -69,17 +62,14 @@ class FlutterHostWindowController {
   // Destroys all windows managed by this controller.
   void DestroyAllWindows();
 
-  // Gets the size of the window hosting the view with ID |view_id|. This is the
-  // size the host window frame, in logical coordinates, and does not include
-  // the dimensions of the drop-shadow area.
-  WindowSize GetWindowSize(FlutterViewId view_id) const;
+  // Gets the size of the host window for the view with ID |view_id|. The size
+  // is in logical coordinates and excludes the drop-shadow area.
+  Size GetWindowSize(FlutterViewId view_id) const;
 
   // Sends the "onWindowChanged" message to the Flutter engine.
-  void SendOnWindowChanged(FlutterViewId view_id) const;
-
-  // Sends the "onWindowCreated" message to the Flutter engine.
-  void SendOnWindowCreated(FlutterViewId view_id,
-                           std::optional<FlutterViewId> parent_view_id) const;
+  void SendOnWindowChanged(FlutterViewId view_id,
+                           std::optional<Size> size,
+                           std::optional<Size> relative_position) const;
 
   // Sends the "onWindowDestroyed" message to the Flutter engine.
   void SendOnWindowDestroyed(FlutterViewId view_id) const;

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window_controller_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window_controller_unittests.cc
@@ -64,7 +64,7 @@ class FlutterHostWindowControllerTest : public WindowsTest {
 TEST_F(FlutterHostWindowControllerTest, CreateRegularWindow) {
   // Define parameters for the window to be created.
   WindowCreationSettings const settings = {
-      .archetype = WindowArchetype::regular,
+      .archetype = WindowArchetype::kRegular,
       .size = {800.0, 600.0},
       .title = "window",
   };
@@ -130,7 +130,7 @@ TEST_F(FlutterHostWindowControllerTest, DestroyWindow) {
 
   // Define parameters for the window to be created.
   WindowCreationSettings const settings = {
-      .archetype = WindowArchetype::regular,
+      .archetype = WindowArchetype::kRegular,
       .size = {800.0, 600.0},
       .title = "window",
   };

--- a/engine/src/flutter/shell/platform/windows/windowing_handler.cc
+++ b/engine/src/flutter/shell/platform/windows/windowing_handler.cc
@@ -134,7 +134,7 @@ void WindowingHandler::HandleMethodCall(
   const std::string& method = method_call.method_name();
 
   if (method == kCreateWindowMethod) {
-    HandleCreateWindow(WindowArchetype::regular, method_call, *result);
+    HandleCreateWindow(WindowArchetype::kRegular, method_call, *result);
   } else if (method == kDestroyWindowMethod) {
     HandleDestroyWindow(method_call, *result);
   } else {
@@ -153,8 +153,8 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
   }
 
   // Helper lambda to check and report invalid window size
-  auto const hasValidWindowSize = [&result](Size size,
-                                            std::string_view key_name) -> bool {
+  auto const has_valid_window_size =
+      [&result](Size size, std::string_view key_name) -> bool {
     if (size.width() <= 0 || size.height() <= 0) {
       result.Error(kInvalidValueError,
                    "Values for the '" + std::string(key_name) + "' key (" +
@@ -176,16 +176,16 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
     return;
   }
   settings.size = {size_list->at(0), size_list->at(1)};
-  if (!hasValidWindowSize(settings.size, kSizeKey)) {
+  if (!has_valid_window_size(settings.size, kSizeKey)) {
     return;
   }
 
-  if (archetype == WindowArchetype::regular) {
+  if (archetype == WindowArchetype::kRegular) {
     // Get value for the 'minSize' key (nullable)
     if (auto const list = GetListOfValuesForKeyOrSendError<double, 2>(
             kMinSizeKey, map, result)) {
       settings.min_size = {list->at(0), list->at(1)};
-      if (!hasValidWindowSize(*settings.min_size, kMinSizeKey)) {
+      if (!has_valid_window_size(*settings.min_size, kMinSizeKey)) {
         return;
       }
     }
@@ -193,7 +193,7 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
     if (auto const list = GetListOfValuesForKeyOrSendError<double, 2>(
             kMaxSizeKey, map, result)) {
       settings.max_size = {list->at(0), list->at(1)};
-      if (!hasValidWindowSize(*settings.max_size, kMaxSizeKey)) {
+      if (!has_valid_window_size(*settings.max_size, kMaxSizeKey)) {
         return;
       }
     }
@@ -214,7 +214,7 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
     WindowMetadata const& data = data_opt.value();
     EncodableMap map;
 
-    if (archetype == WindowArchetype::regular) {
+    if (archetype == WindowArchetype::kRegular) {
       map.insert({EncodableValue(kViewIdKey), EncodableValue(data.view_id)});
       map.insert(
           {EncodableValue(kSizeKey),

--- a/engine/src/flutter/shell/platform/windows/windowing_handler.cc
+++ b/engine/src/flutter/shell/platform/windows/windowing_handler.cc
@@ -103,7 +103,7 @@ std::optional<std::vector<T>> GetListOfValuesForKeyOrSendError(
     return decoded_values;
   }
 
-  // If the value exists but is not a list
+  // If the value exists but is not a list.
   result.Error(kInvalidValueError,
                "Value for key '" + key + "' key must be an array.");
   return std::nullopt;
@@ -152,7 +152,7 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
     return;
   }
 
-  // Helper lambda to check and report invalid window size
+  // Helper lambda to check and report invalid window size.
   auto const has_valid_window_size =
       [&result](Size size, std::string_view key_name) -> bool {
     if (size.width() <= 0 || size.height() <= 0) {
@@ -167,7 +167,7 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
 
   WindowCreationSettings settings;
 
-  // Get value for the 'size' key (non-nullable)
+  // Get value for the 'size' key (non-nullable).
   auto const size_list =
       GetListOfValuesForKeyOrSendError<double, 2>(kSizeKey, map, result);
   if (!size_list) {
@@ -181,7 +181,7 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
   }
 
   if (archetype == WindowArchetype::kRegular) {
-    // Get value for the 'minSize' key (nullable)
+    // Get value for the 'minSize' key (nullable).
     if (auto const list = GetListOfValuesForKeyOrSendError<double, 2>(
             kMinSizeKey, map, result)) {
       settings.min_size = {list->at(0), list->at(1)};
@@ -189,7 +189,7 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
         return;
       }
     }
-    // Get value for the 'maxSize' key (nullable)
+    // Get value for the 'maxSize' key (nullable).
     if (auto const list = GetListOfValuesForKeyOrSendError<double, 2>(
             kMaxSizeKey, map, result)) {
       settings.max_size = {list->at(0), list->at(1)};
@@ -197,11 +197,11 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
         return;
       }
     }
-    // Get value for the 'title' key (nullable)
+    // Get value for the 'title' key (nullable).
     settings.title =
         GetSingleValueForKeyOrSendError<std::string>(kTitleKey, map, result);
 
-    // Get value for the 'state' key (nullable)
+    // Get value for the 'state' key (nullable).
     if (std::optional<std::string> state_string =
             GetSingleValueForKeyOrSendError<std::string>(kStateKey, map,
                                                          result)) {

--- a/engine/src/flutter/shell/platform/windows/windowing_handler.cc
+++ b/engine/src/flutter/shell/platform/windows/windowing_handler.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
+#include "flutter/shell/platform/common/windowing.h"
 
 namespace {
 
@@ -19,16 +20,11 @@ constexpr char kCreateWindowMethod[] = "createWindow";
 constexpr char kDestroyWindowMethod[] = "destroyWindow";
 
 // Keys used in method calls.
-constexpr char kAnchorRectKey[] = "anchorRect";
-constexpr char kArchetypeKey[] = "archetype";
-constexpr char kParentKey[] = "parent";
-constexpr char kParentViewIdKey[] = "parentViewId";
-constexpr char kPositionerChildAnchorKey[] = "positionerChildAnchor";
-constexpr char kPositionerConstraintAdjustmentKey[] =
-    "positionerConstraintAdjustment";
-constexpr char kPositionerOffsetKey[] = "positionerOffset";
-constexpr char kPositionerParentAnchorKey[] = "positionerParentAnchor";
+constexpr char kMaxSizeKey[] = "maxSize";
+constexpr char kMinSizeKey[] = "minSize";
 constexpr char kSizeKey[] = "size";
+constexpr char kStateKey[] = "state";
+constexpr char kTitleKey[] = "title";
 constexpr char kViewIdKey[] = "viewId";
 
 // Error codes used for responses.
@@ -36,79 +32,81 @@ constexpr char kInvalidValueError[] = "Invalid Value";
 constexpr char kUnavailableError[] = "Unavailable";
 
 // Retrieves the value associated with |key| from |map|, ensuring it matches
-// the expected type |T|. Returns the value if found and correctly typed,
-// otherwise logs an error in |result| and returns std::nullopt.
+// the expected type |T| or std::monostate. Returns the value if found and
+// correctly typed, and std::nullopt if the value is null. An error is logged in
+// |result| if |key| doesn't exist, or if it exists but is not of either type
+// |T| or std::monostate.
 template <typename T>
 std::optional<T> GetSingleValueForKeyOrSendError(
     std::string const& key,
     flutter::EncodableMap const* map,
     flutter::MethodResult<>& result) {
-  if (auto const it = map->find(flutter::EncodableValue(key));
-      it != map->end()) {
-    if (auto const* const value = std::get_if<T>(&it->second)) {
-      return *value;
-    } else {
-      result.Error(kInvalidValueError, "Value for '" + key +
-                                           "' key must be of type '" +
-                                           typeid(T).name() + "'.");
-    }
-  } else {
+  auto const it = map->find(flutter::EncodableValue(key));
+  if (it == map->end()) {
     result.Error(kInvalidValueError,
                  "Map does not contain required '" + key + "' key.");
+    return std::nullopt;
   }
+  if (auto const* const value = std::get_if<T>(&it->second)) {
+    return *value;
+  }
+  if (std::holds_alternative<std::monostate>(it->second)) {
+    return std::nullopt;
+  }
+
+  result.Error(kInvalidValueError, "Value for '" + key +
+                                       "' key must be of type '" +
+                                       typeid(T).name() + "'.");
   return std::nullopt;
 }
 
 // Retrieves a list of values associated with |key| from |map|, ensuring the
 // list has |Size| elements, all of type |T|. Returns the list if found and
-// valid, otherwise logs an error in |result| and returns std::nullopt.
+// valid, and sts::nullopt if the value for the key is null. An error is logged
+// in |result| if |key| doesn't exist, or if it exists but is not of either type
+// std::vector<T> or std::monostate.
 template <typename T, size_t Size>
-std::optional<std::vector<T>> GetListValuesForKeyOrSendError(
+std::optional<std::vector<T>> GetListOfValuesForKeyOrSendError(
     std::string const& key,
     flutter::EncodableMap const* map,
     flutter::MethodResult<>& result) {
-  if (auto const it = map->find(flutter::EncodableValue(key));
-      it != map->end()) {
-    if (auto const* const array =
-            std::get_if<std::vector<flutter::EncodableValue>>(&it->second)) {
-      if (array->size() != Size) {
-        result.Error(kInvalidValueError, "Array for '" + key +
-                                             "' key must have " +
-                                             std::to_string(Size) + " values.");
-        return std::nullopt;
-      }
-      std::vector<T> decoded_values;
-      for (flutter::EncodableValue const& value : *array) {
-        if (std::holds_alternative<T>(value)) {
-          decoded_values.push_back(std::get<T>(value));
-        } else {
-          result.Error(kInvalidValueError,
-                       "Array for '" + key +
-                           "' key must only have values of type '" +
-                           typeid(T).name() + "'.");
-          return std::nullopt;
-        }
-      }
-      return decoded_values;
-    } else {
-      result.Error(kInvalidValueError,
-                   "Value for '" + key + "' key must be an array.");
-    }
-  } else {
+  auto const it = map->find(flutter::EncodableValue(key));
+  if (it == map->end()) {
     result.Error(kInvalidValueError,
                  "Map does not contain required '" + key + "' key.");
+    return std::nullopt;
   }
-  return std::nullopt;
-}
+  if (std::holds_alternative<std::monostate>(it->second)) {
+    return std::nullopt;
+  }
+  if (auto const* const array =
+          std::get_if<std::vector<flutter::EncodableValue>>(&it->second)) {
+    if (array->size() != Size) {
+      result.Error(kInvalidValueError, "Array for '" + key +
+                                           "' key must have " +
+                                           std::to_string(Size) + " values.");
+      return std::nullopt;
+    }
+    std::vector<T> decoded_values;
+    decoded_values.reserve(Size);
+    for (flutter::EncodableValue const& value : *array) {
+      if (std::holds_alternative<T>(value)) {
+        decoded_values.push_back(std::get<T>(value));
+      } else {
+        result.Error(kInvalidValueError,
+                     "Array for '" + key +
+                         "' key must only have values of type '" +
+                         typeid(T).name() + "'.");
+        return std::nullopt;
+      }
+    }
+    return decoded_values;
+  }
 
-// Converts a |flutter::WindowArchetype| to its corresponding wide string
-// representation.
-std::wstring ArchetypeToWideString(flutter::WindowArchetype archetype) {
-  switch (archetype) {
-    case flutter::WindowArchetype::regular:
-      return L"regular";
-  }
-  FML_UNREACHABLE();
+  // If the value exists but is not a list
+  result.Error(kInvalidValueError,
+               "Value for key '" + key + "' key must be an array.");
+  return std::nullopt;
 }
 
 }  // namespace
@@ -154,37 +152,80 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
     return;
   }
 
-  std::wstring const title = ArchetypeToWideString(archetype);
+  // Helper lambda to check and report invalid window size
+  auto const hasValidWindowSize = [&result](Size size,
+                                            std::string_view key_name) -> bool {
+    if (size.width() <= 0 || size.height() <= 0) {
+      result.Error(kInvalidValueError,
+                   "Values for the '" + std::string(key_name) + "' key (" +
+                       std::to_string(size.width()) + ", " +
+                       std::to_string(size.height()) + ") must be positive.");
+      return false;
+    }
+    return true;
+  };
 
+  WindowCreationSettings settings;
+
+  // Get value for the 'size' key (non-nullable)
   auto const size_list =
-      GetListValuesForKeyOrSendError<int, 2>(kSizeKey, map, result);
+      GetListOfValuesForKeyOrSendError<double, 2>(kSizeKey, map, result);
   if (!size_list) {
+    result.Error(kInvalidValueError, "Value for '" + std::string(kSizeKey) +
+                                         "' key must not be null.");
     return;
   }
-  if (size_list->at(0) < 0 || size_list->at(1) < 0) {
-    result.Error(kInvalidValueError,
-                 "Values for '" + std::string(kSizeKey) + "' key (" +
-                     std::to_string(size_list->at(0)) + ", " +
-                     std::to_string(size_list->at(1)) +
-                     ") must be nonnegative.");
+  settings.size = {size_list->at(0), size_list->at(1)};
+  if (!hasValidWindowSize(settings.size, kSizeKey)) {
     return;
+  }
+
+  if (archetype == WindowArchetype::regular) {
+    // Get value for the 'minSize' key (nullable)
+    if (auto const list = GetListOfValuesForKeyOrSendError<double, 2>(
+            kMinSizeKey, map, result)) {
+      settings.min_size = {list->at(0), list->at(1)};
+      if (!hasValidWindowSize(*settings.min_size, kMinSizeKey)) {
+        return;
+      }
+    }
+    // Get value for the 'maxSize' key (nullable)
+    if (auto const list = GetListOfValuesForKeyOrSendError<double, 2>(
+            kMaxSizeKey, map, result)) {
+      settings.max_size = {list->at(0), list->at(1)};
+      if (!hasValidWindowSize(*settings.max_size, kMaxSizeKey)) {
+        return;
+      }
+    }
+    // Get value for the 'title' key (nullable)
+    settings.title =
+        GetSingleValueForKeyOrSendError<std::string>(kTitleKey, map, result);
+
+    // Get value for the 'state' key (nullable)
+    if (std::optional<std::string> state_string =
+            GetSingleValueForKeyOrSendError<std::string>(kStateKey, map,
+                                                         result)) {
+      settings.state = StringToWindowState(*state_string);
+    }
   }
 
   if (std::optional<WindowMetadata> const data_opt =
-          controller_->CreateHostWindow(
-              title, {.width = size_list->at(0), .height = size_list->at(1)},
-              archetype)) {
+          controller_->CreateHostWindow(settings)) {
     WindowMetadata const& data = data_opt.value();
-    result.Success(EncodableValue(EncodableMap{
-        {EncodableValue(kViewIdKey), EncodableValue(data.view_id)},
-        {EncodableValue(kArchetypeKey),
-         EncodableValue(static_cast<int>(data.archetype))},
-        {EncodableValue(kSizeKey),
-         EncodableValue(EncodableList{EncodableValue(data.size.width),
-                                      EncodableValue(data.size.height)})},
-        {EncodableValue(kParentViewIdKey),
-         data.parent_id ? EncodableValue(data.parent_id.value())
-                        : EncodableValue()}}));
+    EncodableMap map;
+
+    if (archetype == WindowArchetype::regular) {
+      map.insert({EncodableValue(kViewIdKey), EncodableValue(data.view_id)});
+      map.insert(
+          {EncodableValue(kSizeKey),
+           EncodableValue(EncodableList{EncodableValue(data.size.width()),
+                                        EncodableValue(data.size.height())})});
+      assert(data.state.has_value());
+      map.insert({EncodableValue(kStateKey),
+                  EncodableValue(WindowStateToString(data.state.value()))});
+    }
+
+    result.Success(EncodableValue(map));
   } else {
     result.Error(kUnavailableError, "Can't create window.");
   }
@@ -202,6 +243,8 @@ void WindowingHandler::HandleDestroyWindow(MethodCall<> const& call,
   auto const view_id =
       GetSingleValueForKeyOrSendError<int>(kViewIdKey, map, result);
   if (!view_id) {
+    result.Error(kInvalidValueError, "Value for '" + std::string(kViewIdKey) +
+                                         "' key must not be null.");
     return;
   }
   if (view_id.value() < 0) {

--- a/engine/src/flutter/shell/platform/windows/windowing_handler_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/windowing_handler_unittests.cc
@@ -79,7 +79,7 @@ class WindowingHandlerTest : public WindowsTest {
         .WillByDefault([](WindowCreationSettings const& settings) {
           return WindowMetadata{
               .size = settings.size,
-              .state = WindowState::restored,
+              .state = WindowState::kRestored,
           };
         });
     ON_CALL(*mock_controller_, DestroyHostWindow).WillByDefault(Return(true));
@@ -110,7 +110,7 @@ TEST_F(WindowingHandlerTest, HandleCreateRegularWindow) {
   WindowingHandler windowing_handler(&messenger, controller());
 
   WindowCreationSettings const settings = {
-      .archetype = WindowArchetype::regular,
+      .archetype = WindowArchetype::kRegular,
       .size = {800.0, 600.0},
       .title = "regular",
   };

--- a/examples/multi_window_ref_app/lib/app/regular_window_content.dart
+++ b/examples/multi_window_ref_app/lib/app/regular_window_content.dart
@@ -95,9 +95,8 @@ class _RegularWindowContentState extends State<RegularWindowContent>
                   builder: (BuildContext context, Widget? _) {
                     return Text(
                       'View #${widget.window.view?.viewId ?? "Unknown"}\n'
-                      'Parent View: ${widget.window.parentViewId}\n'
                       'View Size: ${(widget.window.view!.physicalSize.width / dpr).toStringAsFixed(1)}\u00D7${(widget.window.view!.physicalSize.height / dpr).toStringAsFixed(1)}\n'
-                      'Window Size: ${widget.window.size?.width}\u00D7${widget.window.size?.height}\n'
+                      'Window Size: ${(widget.window.size!.width).toStringAsFixed(1)}\u00D7${(widget.window.size!.height).toStringAsFixed(1)}\n'
                       'Device Pixel Ratio: $dpr',
                       textAlign: TextAlign.center,
                     );

--- a/examples/multi_window_ref_app/lib/app/window_controller_render.dart
+++ b/examples/multi_window_ref_app/lib/app/window_controller_render.dart
@@ -26,7 +26,8 @@ class WindowControllerRender extends StatelessWidget {
             key: key,
             onDestroyed: onDestroyed,
             onError: (String? reason) => onError(),
-            preferredSize: windowSettings.regularSize,
+            size: windowSettings.regularSize,
+            title: "Regular",
             controller: controller as RegularWindowController,
             child: RegularWindowContent(
                 window: controller as RegularWindowController,

--- a/examples/multi_window_ref_app/lib/main.dart
+++ b/examples/multi_window_ref_app/lib/main.dart
@@ -6,7 +6,9 @@ void main() {
   runWidget(WindowingApp(children: <Widget>[
     RegularWindow(
         controller: controller,
-        preferredSize: const Size(800, 600),
+        size: const Size(800, 600),
+        sizeConstraints: const BoxConstraints(minWidth: 640, minHeight: 480),
+        title: "Multi-Window Reference Application",
         child: MaterialApp(home: MainWindow(mainController: controller)))
   ]));
 }

--- a/packages/flutter/test/widgets/window_test.dart
+++ b/packages/flutter/test/widgets/window_test.dart
@@ -11,21 +11,9 @@ Future<Object?>? Function(MethodCall)? _createWindowMethodCallHandler(WidgetTest
     final Map<Object?, Object?> args = call.arguments as Map<Object?, Object?>;
     if (call.method == 'createWindow') {
       final List<Object?> size = args['size']! as List<Object?>;
+      final String state = args['state'] as String? ?? WindowState.restored.toString();
 
-      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
-        SystemChannels.windowing.name,
-        SystemChannels.windowing.codec.encodeMethodCall(
-          MethodCall('onWindowCreated',  <String, Object?>{'viewId': tester.view.viewId, 'parentViewId': null}),
-        ),
-        (ByteData? data) {},
-      );
-
-      return <String, Object?>{
-        'viewId': tester.view.viewId,
-        'archetype': WindowArchetype.regular.index,
-        'size': size,
-        'parentViewId': null,
-      };
+      return <String, Object?>{'viewId': tester.view.viewId, 'size': size, 'state': state};
     } else if (call.method == 'destroyWindow') {
       await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
         SystemChannels.windowing.name,
@@ -60,7 +48,7 @@ void main() {
         builder: (BuildContext context) {
           return WindowingApp(
             children: <Widget>[
-              RegularWindow(controller: controller, preferredSize: windowSize, child: Container()),
+              RegularWindow(controller: controller, size: windowSize, child: Container()),
             ],
           );
         },
@@ -102,7 +90,7 @@ void main() {
                   );
                   receivedError = true;
                 },
-                preferredSize: windowSize,
+                size: windowSize,
                 child: Container(),
               ),
             ],
@@ -136,7 +124,7 @@ void main() {
             children: <Widget>[
               RegularWindow(
                 controller: controller,
-                preferredSize: windowSize,
+                size: windowSize,
                 onDestroyed: () {
                   destroyed = true;
                 },
@@ -175,7 +163,7 @@ void main() {
               children: <Widget>[
                 RegularWindow(
                   controller: controller,
-                  preferredSize: initialSize,
+                  size: initialSize,
                   child: Container(),
                 ),
               ],
@@ -191,7 +179,7 @@ void main() {
         SystemChannels.windowing.codec.encodeMethodCall(
           MethodCall('onWindowChanged',  <String, Object?>{
             'viewId': tester.view.viewId,
-            'size': <int>[newSize.width.toInt(), newSize.height.toInt()],
+            'size': <double>[newSize.width, newSize.height],
           }),
         ),
         (ByteData? data) {},


### PR DESCRIPTION
## What's new
* Added support for setting the initial window state, size constraints, and the window title.
* Updated `createRegular` arguments to:
  ```dart
    Map<String, dynamic>{
      "size": List<double>,           // [width, height]
      "minSize": List<double> | null, // [width, height]
      "maxSize": List<double> | null, // [width, height]
      "title": String | null,
      "state": String | null,         // WindowState as String
    }
  ```
  with the return value:
  ```dart
  Map<String, dynamic>{
    "viewId": int,
    "size": List<double>, // [width, height]
    "state": String,      // WindowState as String
  }
  ```
* Update `onWindowChanged` arguments to:
  ```dart
  Map<String, dynamic>{
    "viewId": int,
    "size": List<double> | null,             // [width, height]
    "relativePosition": List<double> | null, // [dx, dy]
  }
  ```
* Removed `onWindowCreated`
* Replaced `WindowSize` with `Size` from `geometry.h`
* Removed `WindowPoint` and `WindowRectangle` (not needed for regular windows; other archetypes will use `Size` and `Rect` from `geometry.h`)
* Updated framework to use the new method channel format
* Renamed `preferredSize` to `size`
* Used `BoxConstraints` for defining the minimum and maximum sizes
* Updated unit tests in the embedder and framework
* Updated the reference app
* Performed several smaller refactorings to improve readability