### PR TITLE
feature: implemented modifyRegular + fixed a bug where a widget tree was mandatory on accident

### DIFF
--- a/engine/src/flutter/shell/platform/common/geometry.h
+++ b/engine/src/flutter/shell/platform/common/geometry.h
@@ -45,6 +45,7 @@ class Size {
   bool operator==(const Size& other) const {
     return width_ == other.width_ && height_ == other.height_;
   }
+  bool operator!=(const Size& other) const { return !(*this == other); }
 
  private:
   double width_ = 0.0;

--- a/engine/src/flutter/shell/platform/common/windowing.h
+++ b/engine/src/flutter/shell/platform/common/windowing.h
@@ -75,6 +75,16 @@ struct WindowCreationSettings {
   std::optional<WindowState> state;
 };
 
+// Settings for modifying a Flutter window.
+struct WindowModificationSettings {
+  // The new requested size, in logical coordinates.
+  std::optional<Size> size;
+  // The new window title.
+  std::optional<std::string> title;
+  // The new window state.
+  std::optional<WindowState> state;
+};
+
 // Window metadata returned as the result of creating a Flutter window.
 struct WindowMetadata {
   // The ID of the view used for this window, which is unique to each window.

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
@@ -446,10 +446,6 @@ FlutterHostWindow* FlutterHostWindow::GetThisFromHandle(HWND hwnd) {
       GetWindowLongPtr(hwnd, GWLP_USERDATA));
 }
 
-WindowState FlutterHostWindow::GetState() const {
-  return state_;
-}
-
 HWND FlutterHostWindow::GetWindowHandle() const {
   return window_handle_;
 }
@@ -591,6 +587,25 @@ void FlutterHostWindow::SetChildContent(HWND content) {
   MoveWindow(content, client_rect.left, client_rect.top,
              client_rect.right - client_rect.left,
              client_rect.bottom - client_rect.top, true);
+}
+
+void FlutterHostWindow::SetState(WindowState state) {
+  WINDOWPLACEMENT window_placement = {.length = sizeof(WINDOWPLACEMENT)};
+  GetWindowPlacement(window_handle_, &window_placement);
+  window_placement.showCmd = [&]() {
+    switch (state) {
+      case WindowState::kRestored:
+        return SW_RESTORE;
+      case WindowState::kMaximized:
+        return SW_MAXIMIZE;
+      case WindowState::kMinimized:
+        return SW_MINIMIZE;
+      default:
+        FML_UNREACHABLE();
+    };
+  }();
+  SetWindowPlacement(window_handle_, &window_placement);
+  state_ = state;
 }
 
 void FlutterHostWindow::SetTitle(std::string_view title) const {

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
@@ -213,16 +213,15 @@ bool IsClassRegistered(LPCWSTR class_name) {
 }
 
 // Convert std::string to std::wstring.
-std::wstring StringToWstring(std::string const& str) {
+std::wstring StringToWstring(std::string_view str) {
   if (str.empty()) {
     return {};
   }
   if (int buffer_size =
-          MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0)) {
+          MultiByteToWideChar(CP_UTF8, 0, str.data(), str.size(), nullptr, 0)) {
     std::wstring wide_str(buffer_size, L'\0');
-    if (MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wide_str[0],
+    if (MultiByteToWideChar(CP_UTF8, 0, str.data(), str.size(), &wide_str[0],
                             buffer_size)) {
-      wide_str.pop_back();
       return wide_str;
     }
   }
@@ -447,28 +446,12 @@ FlutterHostWindow* FlutterHostWindow::GetThisFromHandle(HWND hwnd) {
       GetWindowLongPtr(hwnd, GWLP_USERDATA));
 }
 
-WindowArchetype FlutterHostWindow::GetArchetype() const {
-  return archetype_;
-}
-
-FlutterViewId FlutterHostWindow::GetFlutterViewId() const {
-  return view_controller_->view()->view_id();
-};
-
 WindowState FlutterHostWindow::GetState() const {
   return state_;
 }
 
 HWND FlutterHostWindow::GetWindowHandle() const {
   return window_handle_;
-}
-
-void FlutterHostWindow::SetQuitOnClose(bool quit_on_close) {
-  quit_on_close_ = quit_on_close;
-}
-
-bool FlutterHostWindow::GetQuitOnClose() const {
-  return quit_on_close_;
 }
 
 void FlutterHostWindow::FocusViewOf(FlutterHostWindow* window) {
@@ -587,6 +570,19 @@ LRESULT FlutterHostWindow::HandleMessage(HWND hwnd,
   return DefWindowProc(hwnd, message, wparam, lparam);
 }
 
+void FlutterHostWindow::SetClientSize(Size const& client_size) const {
+  WINDOWINFO window_info = {.cbSize = sizeof(WINDOWINFO)};
+  GetWindowInfo(window_handle_, &window_info);
+
+  std::optional<Size> const window_size = GetWindowSizeForClientSize(
+      client_size, min_size_, max_size_, window_info.dwStyle,
+      window_info.dwExStyle, nullptr);
+
+  Size const size = window_size.value_or(client_size);
+  SetWindowPos(window_handle_, NULL, 0, 0, size.width(), size.height(),
+               SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
 void FlutterHostWindow::SetChildContent(HWND content) {
   child_content_ = content;
   SetParent(content, window_handle_);
@@ -595,6 +591,11 @@ void FlutterHostWindow::SetChildContent(HWND content) {
   MoveWindow(content, client_rect.left, client_rect.top,
              client_rect.right - client_rect.left,
              client_rect.bottom - client_rect.top, true);
+}
+
+void FlutterHostWindow::SetTitle(std::string_view title) const {
+  std::wstring title_wide = StringToWstring(title);
+  SetWindowText(window_handle_, title_wide.c_str());
 }
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
@@ -450,6 +450,10 @@ HWND FlutterHostWindow::GetWindowHandle() const {
   return window_handle_;
 }
 
+WindowState FlutterHostWindow::GetState() const {
+  return state_;
+}
+
 void FlutterHostWindow::FocusViewOf(FlutterHostWindow* window) {
   if (window != nullptr && window->child_content_ != nullptr) {
     SetFocus(window->child_content_);

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.h
@@ -33,9 +33,6 @@ class FlutterHostWindow {
   // Returns the instance pointer for |hwnd| or nulllptr if invalid.
   static FlutterHostWindow* GetThisFromHandle(HWND hwnd);
 
-  // Returns the current window state.
-  WindowState GetState() const;
-
   // Returns the backing window handle, or nullptr if the native window is not
   // created or has already been destroyed.
   HWND GetWindowHandle() const;
@@ -62,6 +59,9 @@ class FlutterHostWindow {
 
   // Inserts |content| into the window tree.
   void SetChildContent(HWND content);
+
+  // Sets the window state.
+  void SetState(WindowState state);
 
   // Sets the window title.
   void SetTitle(std::string_view title) const;

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.h
@@ -33,24 +33,12 @@ class FlutterHostWindow {
   // Returns the instance pointer for |hwnd| or nulllptr if invalid.
   static FlutterHostWindow* GetThisFromHandle(HWND hwnd);
 
-  // Returns the window archetype.
-  WindowArchetype GetArchetype() const;
-
-  // Returns the hosted Flutter view's ID.
-  FlutterViewId GetFlutterViewId() const;
-
   // Returns the current window state.
   WindowState GetState() const;
 
   // Returns the backing window handle, or nullptr if the native window is not
   // created or has already been destroyed.
   HWND GetWindowHandle() const;
-
-  // Sets whether closing this window will quit the application.
-  void SetQuitOnClose(bool quit_on_close);
-
-  // Returns whether closing this window will quit the application.
-  bool GetQuitOnClose() const;
 
  private:
   friend FlutterHostWindowController;
@@ -69,8 +57,14 @@ class FlutterHostWindow {
   // inheriting classes can handle.
   LRESULT HandleMessage(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam);
 
+  // Resizes the window to accommodate a client area of the given |client_size|.
+  void SetClientSize(Size const& client_size) const;
+
   // Inserts |content| into the window tree.
   void SetChildContent(HWND content);
+
+  // Sets the window title.
+  void SetTitle(std::string_view title) const;
 
   // Controller for this window.
   FlutterHostWindowController* const window_controller_;

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.h
@@ -33,6 +33,9 @@ class FlutterHostWindow {
   // Returns the instance pointer for |hwnd| or nulllptr if invalid.
   static FlutterHostWindow* GetThisFromHandle(HWND hwnd);
 
+  // Returns the current window state.
+  WindowState GetState() const;
+
   // Returns the backing window handle, or nullptr if the native window is not
   // created or has already been destroyed.
   HWND GetWindowHandle() const;

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
@@ -100,7 +100,7 @@ bool FlutterHostWindowController::ModifyHostWindow(
   }
 
   Size const size_after = GetViewSize(view_id);
-  if (!(size_before == size_after)) {
+  if (size_before != size_after) {
     changed_size = size_after;
   }
 

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
@@ -69,8 +69,6 @@ bool FlutterHostWindowController::ModifyHostWindow(
     return false;
   }
 
-  HWND const window_handle = window->GetWindowHandle();
-
   std::optional<Size> changed_size;
   Size const size_before = GetViewSize(view_id);
 
@@ -81,22 +79,7 @@ bool FlutterHostWindowController::ModifyHostWindow(
     window->SetTitle(*settings.title);
   }
   if (settings.state.has_value()) {
-    WINDOWPLACEMENT window_placement = {.length = sizeof(WINDOWPLACEMENT)};
-    if (GetWindowPlacement(window_handle, &window_placement)) {
-      window_placement.showCmd = [&]() {
-        switch (*settings.state) {
-          case WindowState::kRestored:
-            return SW_RESTORE;
-          case WindowState::kMaximized:
-            return SW_MAXIMIZE;
-          case WindowState::kMinimized:
-            return SW_MINIMIZE;
-          default:
-            FML_UNREACHABLE();
-        };
-      }();
-      SetWindowPlacement(window_handle, &window_placement);
-    }
+    window->SetState(*settings.state);
   }
 
   Size const size_after = GetViewSize(view_id);

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
@@ -39,7 +39,9 @@ FlutterHostWindowController::~FlutterHostWindowController() {
 std::optional<WindowMetadata> FlutterHostWindowController::CreateHostWindow(
     WindowCreationSettings const& settings) {
   auto window = std::make_unique<FlutterHostWindow>(this, settings);
+
   if (!window->GetWindowHandle()) {
+    FML_LOG(ERROR) << "Failed to create host window";
     return std::nullopt;
   }
 
@@ -66,6 +68,7 @@ bool FlutterHostWindowController::ModifyHostWindow(
     WindowModificationSettings const& settings) const {
   FlutterHostWindow* const window = GetHostWindow(view_id);
   if (!window) {
+    FML_LOG(ERROR) << "Failed to find window with view ID " << view_id;
     return false;
   }
 
@@ -96,13 +99,16 @@ bool FlutterHostWindowController::ModifyHostWindow(
 
 bool FlutterHostWindowController::DestroyHostWindow(
     FlutterViewId view_id) const {
-  if (FlutterHostWindow* const window = GetHostWindow(view_id)) {
-    // |window| will be removed from |windows_| when WM_NCDESTROY is handled.
-    PostMessage(window->GetWindowHandle(), WM_CLOSE, 0, 0);
-
-    return true;
+  FlutterHostWindow* const window = GetHostWindow(view_id);
+  if (!window) {
+    FML_LOG(ERROR) << "Failed to find window with view ID " << view_id;
+    return false;
   }
-  return false;
+
+  // |window| will be removed from |windows_| when WM_NCDESTROY is handled.
+  PostMessage(window->GetWindowHandle(), WM_CLOSE, 0, 0);
+
+  return true;
 }
 
 FlutterHostWindow* FlutterHostWindowController::GetHostWindow(

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.cc
@@ -72,13 +72,10 @@ bool FlutterHostWindowController::ModifyHostWindow(
   HWND const window_handle = window->GetWindowHandle();
 
   std::optional<Size> changed_size;
+  Size const size_before = GetViewSize(view_id);
+
   if (settings.size.has_value()) {
-    Size const view_size_before = GetViewSize(view_id);
     window->SetClientSize(*settings.size);
-    Size const view_size_after = GetViewSize(view_id);
-    if (!(view_size_before == view_size_after)) {
-      changed_size = view_size_after;
-    }
   }
   if (settings.title.has_value()) {
     window->SetTitle(*settings.title);
@@ -100,6 +97,11 @@ bool FlutterHostWindowController::ModifyHostWindow(
       }();
       SetWindowPlacement(window_handle, &window_placement);
     }
+  }
+
+  Size const size_after = GetViewSize(view_id);
+  if (!(size_before == size_after)) {
+    changed_size = size_after;
   }
 
   if (changed_size) {

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window_controller.h
@@ -34,11 +34,21 @@ class FlutterHostWindowController {
   virtual std::optional<WindowMetadata> CreateHostWindow(
       WindowCreationSettings const& settings);
 
+  // Modifies the attributes of the window hosting the view with ID |view_id|
+  // according to the given |settings|. A "onWindowChanged" message is sent if
+  // at least one attribute is modified.
+  //
+  // Returns false if the controller does not have a window hosting a view with
+  // ID |view_id|.
+  virtual bool ModifyHostWindow(
+      FlutterViewId view_id,
+      WindowModificationSettings const& settings) const;
+
   // Destroys the window that hosts the view with ID |view_id|.
   //
   // Returns false if the controller does not have a window hosting a view with
   // ID |view_id|.
-  virtual bool DestroyHostWindow(FlutterViewId view_id);
+  virtual bool DestroyHostWindow(FlutterViewId view_id) const;
 
   // Gets the window hosting the view with ID |view_id|.
   //
@@ -62,9 +72,8 @@ class FlutterHostWindowController {
   // Destroys all windows managed by this controller.
   void DestroyAllWindows();
 
-  // Gets the size of the host window for the view with ID |view_id|. The size
-  // is in logical coordinates and excludes the drop-shadow area.
-  Size GetWindowSize(FlutterViewId view_id) const;
+  // Retrieves the size of the view with ID |view_id|, in logical coordinates.
+  Size GetViewSize(FlutterViewId view_id) const;
 
   // Sends the "onWindowChanged" message to the Flutter engine.
   void SendOnWindowChanged(FlutterViewId view_id,

--- a/engine/src/flutter/shell/platform/windows/windowing_handler.cc
+++ b/engine/src/flutter/shell/platform/windows/windowing_handler.cc
@@ -14,7 +14,10 @@ namespace {
 constexpr char kChannelName[] = "flutter/windowing";
 
 // Methods for creating different types of windows.
-constexpr char kCreateWindowMethod[] = "createWindow";
+constexpr char kCreateRegularMethod[] = "createRegular";
+
+// Methods for modifying the attributes of windows.
+constexpr char kModifyRegularMethod[] = "modifyRegular";
 
 // The method to destroy a window.
 constexpr char kDestroyWindowMethod[] = "destroyWindow";
@@ -32,12 +35,14 @@ constexpr char kInvalidValueError[] = "Invalid Value";
 constexpr char kUnavailableError[] = "Unavailable";
 
 // Retrieves the value associated with |key| from |map|, ensuring it matches
-// the expected type |T| or std::monostate. Returns the value if found and
-// correctly typed, and std::nullopt if the value is null. An error is logged in
-// |result| if |key| doesn't exist, or if it exists but is not of either type
-// |T| or std::monostate.
+// the expected type |T| or std::monostate. Returns a pair where the first
+// element is the value if found and correctly typed (or std::nullopt if the
+// value is null), and the second element is a boolean indicating success (true)
+// or error (false). If |key| doesn't exist, or if it exists but is not of
+// either type |T| or std::monostate, an error is logged in |result| and the
+// function returns {std::nullopt, false}.
 template <typename T>
-std::optional<T> GetSingleValueForKeyOrSendError(
+std::pair<std::optional<T>, bool> GetSingleValueForKeyOrSendError(
     std::string const& key,
     flutter::EncodableMap const* map,
     flutter::MethodResult<>& result) {
@@ -45,28 +50,32 @@ std::optional<T> GetSingleValueForKeyOrSendError(
   if (it == map->end()) {
     result.Error(kInvalidValueError,
                  "Map does not contain required '" + key + "' key.");
-    return std::nullopt;
+    return {std::nullopt, false};
   }
   if (auto const* const value = std::get_if<T>(&it->second)) {
-    return *value;
+    return {*value, true};
   }
   if (std::holds_alternative<std::monostate>(it->second)) {
-    return std::nullopt;
+    return {std::nullopt, true};
   }
 
   result.Error(kInvalidValueError, "Value for '" + key +
                                        "' key must be of type '" +
                                        typeid(T).name() + "'.");
-  return std::nullopt;
+  return {std::nullopt, false};
 }
 
 // Retrieves a list of values associated with |key| from |map|, ensuring the
-// list has |Size| elements, all of type |T|. Returns the list if found and
-// valid, and sts::nullopt if the value for the key is null. An error is logged
-// in |result| if |key| doesn't exist, or if it exists but is not of either type
-// std::vector<T> or std::monostate.
-template <typename T, size_t Size>
-std::optional<std::vector<T>> GetListOfValuesForKeyOrSendError(
+// list has only elements of type |T|. If |Size| is provided and greater than 0,
+// the number of elements in the list is also checked. Returns a pair where the
+// first element is the list of values and the second element is a boolean
+// indicating success (true) or error (false). The first element of the pair is
+// set to std::nullopt on error or if the value for the key is null. If |key|
+// doesn't exist, or if it exists but is not of either type std::vector<T> or
+// std::monostate, an error is logged in |result| and the function returns
+// {std::nullopt, false}.
+template <typename T, size_t Size = 0>
+std::pair<std::optional<std::vector<T>>, bool> GetListOfValuesForKeyOrSendError(
     std::string const& key,
     flutter::EncodableMap const* map,
     flutter::MethodResult<>& result) {
@@ -74,21 +83,23 @@ std::optional<std::vector<T>> GetListOfValuesForKeyOrSendError(
   if (it == map->end()) {
     result.Error(kInvalidValueError,
                  "Map does not contain required '" + key + "' key.");
-    return std::nullopt;
+    return {std::nullopt, false};
   }
   if (std::holds_alternative<std::monostate>(it->second)) {
-    return std::nullopt;
+    return {std::nullopt, true};
   }
   if (auto const* const array =
           std::get_if<std::vector<flutter::EncodableValue>>(&it->second)) {
-    if (array->size() != Size) {
+    if (Size && array->size() != Size) {
       result.Error(kInvalidValueError, "Array for '" + key +
                                            "' key must have " +
                                            std::to_string(Size) + " values.");
-      return std::nullopt;
+      return {std::nullopt, false};
     }
     std::vector<T> decoded_values;
-    decoded_values.reserve(Size);
+    if (Size) {
+      decoded_values.reserve(Size);
+    }
     for (flutter::EncodableValue const& value : *array) {
       if (std::holds_alternative<T>(value)) {
         decoded_values.push_back(std::get<T>(value));
@@ -97,16 +108,15 @@ std::optional<std::vector<T>> GetListOfValuesForKeyOrSendError(
                      "Array for '" + key +
                          "' key must only have values of type '" +
                          typeid(T).name() + "'.");
-        return std::nullopt;
+        return {std::nullopt, false};
       }
     }
-    return decoded_values;
+    return {std::move(decoded_values), true};
   }
 
-  // If the value exists but is not a list.
   result.Error(kInvalidValueError,
                "Value for key '" + key + "' key must be an array.");
-  return std::nullopt;
+  return {std::nullopt, false};
 }
 
 }  // namespace
@@ -133,8 +143,10 @@ void WindowingHandler::HandleMethodCall(
     std::unique_ptr<MethodResult<EncodableValue>> result) {
   const std::string& method = method_call.method_name();
 
-  if (method == kCreateWindowMethod) {
+  if (method == kCreateRegularMethod) {
     HandleCreateWindow(WindowArchetype::kRegular, method_call, *result);
+  } else if (method == kModifyRegularMethod) {
+    HandleModifyWindow(WindowArchetype::kRegular, method_call, *result);
   } else if (method == kDestroyWindowMethod) {
     HandleDestroyWindow(method_call, *result);
   } else {
@@ -152,60 +164,65 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
     return;
   }
 
-  // Helper lambda to check and report invalid window size.
-  auto const has_valid_window_size =
-      [&result](Size size, std::string_view key_name) -> bool {
-    if (size.width() <= 0 || size.height() <= 0) {
-      result.Error(kInvalidValueError,
-                   "Values for the '" + std::string(key_name) + "' key (" +
-                       std::to_string(size.width()) + ", " +
-                       std::to_string(size.height()) + ") must be positive.");
-      return false;
-    }
-    return true;
-  };
-
   WindowCreationSettings settings;
 
   // Get value for the 'size' key (non-nullable).
-  auto const size_list =
-      GetListOfValuesForKeyOrSendError<double, 2>(kSizeKey, map, result);
-  if (!size_list) {
-    result.Error(kInvalidValueError, "Value for '" + std::string(kSizeKey) +
-                                         "' key must not be null.");
-    return;
-  }
-  settings.size = {size_list->at(0), size_list->at(1)};
-  if (!has_valid_window_size(settings.size, kSizeKey)) {
+  if (auto const [size_list, success] =
+          GetListOfValuesForKeyOrSendError<double, 2>(kSizeKey, map, result);
+      success) {
+    if (!size_list.has_value()) {
+      result.Error(kInvalidValueError, "Value for the '" +
+                                           std::string(kSizeKey) +
+                                           "' key must not be null.");
+      return;
+    }
+    settings.size = {size_list->at(0), size_list->at(1)};
+  } else {
     return;
   }
 
   if (archetype == WindowArchetype::kRegular) {
     // Get value for the 'minSize' key (nullable).
-    if (auto const list = GetListOfValuesForKeyOrSendError<double, 2>(
-            kMinSizeKey, map, result)) {
-      settings.min_size = {list->at(0), list->at(1)};
-      if (!has_valid_window_size(*settings.min_size, kMinSizeKey)) {
-        return;
+    if (auto const [list, success] =
+            GetListOfValuesForKeyOrSendError<double, 2>(kMinSizeKey, map,
+                                                        result);
+        success) {
+      if (list.has_value()) {
+        settings.min_size = {list->at(0), list->at(1)};
       }
+    } else {
+      return;
     }
     // Get value for the 'maxSize' key (nullable).
-    if (auto const list = GetListOfValuesForKeyOrSendError<double, 2>(
-            kMaxSizeKey, map, result)) {
-      settings.max_size = {list->at(0), list->at(1)};
-      if (!has_valid_window_size(*settings.max_size, kMaxSizeKey)) {
-        return;
+    if (auto const [list, success] =
+            GetListOfValuesForKeyOrSendError<double, 2>(kMaxSizeKey, map,
+                                                        result);
+        success) {
+      if (list.has_value()) {
+        settings.max_size = {list->at(0), list->at(1)};
       }
+    } else {
+      return;
     }
     // Get value for the 'title' key (nullable).
-    settings.title =
-        GetSingleValueForKeyOrSendError<std::string>(kTitleKey, map, result);
-
+    if (auto const [title, success] =
+            GetSingleValueForKeyOrSendError<std::string>(kTitleKey, map,
+                                                         result);
+        success) {
+      settings.title = title;
+    } else {
+      return;
+    }
     // Get value for the 'state' key (nullable).
-    if (std::optional<std::string> state_string =
+    if (auto const [state, success] =
             GetSingleValueForKeyOrSendError<std::string>(kStateKey, map,
-                                                         result)) {
-      settings.state = StringToWindowState(*state_string);
+                                                         result);
+        success) {
+      if (state) {
+        settings.state = StringToWindowState(*state);
+      }
+    } else {
+      return;
     }
   }
 
@@ -231,6 +248,70 @@ void WindowingHandler::HandleCreateWindow(WindowArchetype archetype,
   }
 }
 
+void WindowingHandler::HandleModifyWindow(WindowArchetype archetype,
+                                          MethodCall<> const& call,
+                                          MethodResult<>& result) {
+  auto const* const arguments = call.arguments();
+  auto const* const map = std::get_if<EncodableMap>(arguments);
+  if (!map) {
+    result.Error(kInvalidValueError, "Method call argument is not a map.");
+    return;
+  }
+
+  FlutterViewId view_id = {};
+  WindowModificationSettings settings;
+
+  // Get value for the 'viewId' key (non-nullable)
+  if (auto const [data, success] =
+          GetSingleValueForKeyOrSendError<int>(kViewIdKey, map, result);
+      success) {
+    if (!data.has_value()) {
+      result.Error(kInvalidValueError, "Value for the '" +
+                                           std::string(kViewIdKey) +
+                                           "' key must not be null.");
+      return;
+    }
+    view_id = *data;
+  } else {
+    return;
+  }
+  // Get value for the 'size' key (nullable).
+  if (auto const [data, success] =
+          GetListOfValuesForKeyOrSendError<double, 2>(kSizeKey, map, result);
+      success) {
+    if (data.has_value()) {
+      settings.size = {data->at(0), data->at(1)};
+    }
+  } else {
+    return;
+  }
+  // Get value for the 'title' key (nullable).
+  if (auto const [data, success] =
+          GetSingleValueForKeyOrSendError<std::string>(kTitleKey, map, result);
+      success) {
+    settings.title = data;
+  } else {
+    return;
+  }
+  // Get value for the 'state' key (nullable).
+  if (auto const [data, success] =
+          GetSingleValueForKeyOrSendError<std::string>(kStateKey, map, result);
+      success) {
+    if (data) {
+      settings.state = StringToWindowState(*data);
+    }
+  } else {
+    return;
+  }
+
+  if (!controller_->ModifyHostWindow(view_id, settings)) {
+    result.Error(kInvalidValueError, "Can't find window with view ID " +
+                                         std::to_string(view_id) + ".");
+  }
+
+  result.Success();
+}
+
 void WindowingHandler::HandleDestroyWindow(MethodCall<> const& call,
                                            MethodResult<>& result) {
   auto const* const arguments = call.arguments();
@@ -240,28 +321,31 @@ void WindowingHandler::HandleDestroyWindow(MethodCall<> const& call,
     return;
   }
 
-  auto const view_id =
-      GetSingleValueForKeyOrSendError<int>(kViewIdKey, map, result);
-  if (!view_id) {
-    result.Error(kInvalidValueError, "Value for '" + std::string(kViewIdKey) +
-                                         "' key must not be null.");
+  // Get value for the 'viewId' key (non-nullable).
+  if (auto const [view_id_opt, success] =
+          GetSingleValueForKeyOrSendError<int>(kViewIdKey, map, result);
+      success) {
+    if (!view_id_opt.has_value()) {
+      result.Error(kInvalidValueError, "Value for the '" +
+                                           std::string(kViewIdKey) +
+                                           "' key must not be null.");
+      return;
+    }
+    if (*view_id_opt < 0) {
+      result.Error(kInvalidValueError,
+                   "Value for '" + std::string(kViewIdKey) + "' (" +
+                       std::to_string(*view_id_opt) + ") cannot be negative.");
+      return;
+    }
+    if (!controller_->DestroyHostWindow(*view_id_opt)) {
+      result.Error(kInvalidValueError, "Can't find window with view ID " +
+                                           std::to_string(*view_id_opt) + ".");
+      return;
+    }
+    result.Success();
+  } else {
     return;
   }
-  if (view_id.value() < 0) {
-    result.Error(kInvalidValueError,
-                 "Value for '" + std::string(kViewIdKey) + "' (" +
-                     std::to_string(view_id.value()) + ") cannot be negative.");
-    return;
-  }
-
-  if (!controller_->DestroyHostWindow(view_id.value())) {
-    result.Error(kInvalidValueError,
-                 "Can't find window with '" + std::string(kViewIdKey) + "' (" +
-                     std::to_string(view_id.value()) + ").");
-    return;
-  }
-
-  result.Success();
 }
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/windowing_handler.h
+++ b/engine/src/flutter/shell/platform/windows/windowing_handler.h
@@ -19,13 +19,18 @@ class WindowingHandler {
 
  private:
   // Handler for method calls received on |channel_|. Messages are
-  // redirected to either HandleCreateWindow or HandleDestroyWindow.
+  // redirected to HandleCreateWindow, HandlerModifyWindow or
+  // HandleDestroyWindow.
   void HandleMethodCall(
       const flutter::MethodCall<EncodableValue>& method_call,
       std::unique_ptr<flutter::MethodResult<EncodableValue>> result);
 
   // Handles the creation of windows.
   void HandleCreateWindow(flutter::WindowArchetype archetype,
+                          flutter::MethodCall<> const& call,
+                          flutter::MethodResult<>& result);
+  // Handles the modification of window attributes.
+  void HandleModifyWindow(flutter::WindowArchetype archetype,
                           flutter::MethodCall<> const& call,
                           flutter::MethodResult<>& result);
   // Handles the destruction of windows.

--- a/examples/multi_window_ref_app/lib/app/main_window.dart
+++ b/examples/multi_window_ref_app/lib/app/main_window.dart
@@ -141,8 +141,9 @@ class _ActiveWindowsTable extends StatelessWidget {
                 selected: controller.controller == windowManagerModel.selected,
                 onSelectChanged: (selected) {
                   if (selected != null) {
-                    windowManagerModel.select(
-                        selected ? controller.controller.view?.viewId : null);
+                    windowManagerModel.select(selected
+                        ? controller.controller.rootView.viewId
+                        : null);
                   }
                 },
                 cells: [
@@ -151,7 +152,7 @@ class _ActiveWindowsTable extends StatelessWidget {
                         listenable: controller.controller,
                         builder: (BuildContext context, Widget? _) => Text(
                             controller.controller.isReady
-                                ? '${controller.controller.view.viewId}'
+                                ? '${controller.controller.rootView.viewId}'
                                 : 'Loading...')),
                   ),
                   DataCell(

--- a/examples/multi_window_ref_app/lib/app/regular_window_content.dart
+++ b/examples/multi_window_ref_app/lib/app/regular_window_content.dart
@@ -101,10 +101,14 @@ class _RegularWindowContentState extends State<RegularWindowContent>
               ListenableBuilder(
                   listenable: widget.window,
                   builder: (BuildContext context, Widget? _) {
+                    if (!widget.window.isReady) {
+                      return const Text('View not ready');
+                    }
+
                     return Text(
-                      'View #${widget.window.view?.viewId ?? "Unknown"}\n'
-                      'View Size: ${(widget.window.view!.physicalSize.width / dpr).toStringAsFixed(1)}\u00D7${(widget.window.view!.physicalSize.height / dpr).toStringAsFixed(1)}\n'
-                      'Window Size: ${(widget.window.size!.width).toStringAsFixed(1)}\u00D7${(widget.window.size!.height).toStringAsFixed(1)}\n'
+                      'View #${widget.window.rootView.viewId}\n'
+                      'View Size: ${(widget.window.rootView.physicalSize.width / dpr).toStringAsFixed(1)}\u00D7${(widget.window.rootView.physicalSize.height / dpr).toStringAsFixed(1)}\n'
+                      'Window Size: ${(widget.window.size.width).toStringAsFixed(1)}\u00D7${(widget.window.size.height).toStringAsFixed(1)}\n'
                       'Device Pixel Ratio: $dpr',
                       textAlign: TextAlign.center,
                     );

--- a/examples/multi_window_ref_app/lib/app/regular_window_content.dart
+++ b/examples/multi_window_ref_app/lib/app/regular_window_content.dart
@@ -107,8 +107,7 @@ class _RegularWindowContentState extends State<RegularWindowContent>
 
                     return Text(
                       'View #${widget.window.rootView.viewId}\n'
-                      'View Size: ${(widget.window.rootView.physicalSize.width / dpr).toStringAsFixed(1)}\u00D7${(widget.window.rootView.physicalSize.height / dpr).toStringAsFixed(1)}\n'
-                      'Window Size: ${(widget.window.size.width).toStringAsFixed(1)}\u00D7${(widget.window.size.height).toStringAsFixed(1)}\n'
+                      'Size: ${(widget.window.size.width).toStringAsFixed(1)}\u00D7${(widget.window.size.height).toStringAsFixed(1)}\n'
                       'Device Pixel Ratio: $dpr',
                       textAlign: TextAlign.center,
                     );

--- a/examples/multi_window_ref_app/lib/app/window_manager_model.dart
+++ b/examples/multi_window_ref_app/lib/app/window_manager_model.dart
@@ -26,7 +26,7 @@ class WindowManagerModel extends ChangeNotifier {
     }
 
     for (final KeyedWindowController controller in _windows) {
-      if (controller.controller.view.viewId == _selectedViewId) {
+      if (controller.controller.rootView.viewId == _selectedViewId) {
         return controller.controller;
       }
     }

--- a/examples/multi_window_ref_app/pubspec.yaml
+++ b/examples/multi_window_ref_app/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   stack_trace: ^1.11.1
+  vector_math: ^2.1.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter/lib/src/widgets/window.dart
+++ b/packages/flutter/lib/src/widgets/window.dart
@@ -346,7 +346,7 @@ Future<_RegularWindowCreationResult> _createRegular({
 }) async {
   WidgetsFlutterBinding.ensureInitialized();
   final Map<Object?, Object?> creationData =
-      await SystemChannels.windowing.invokeMethod('createWindow', <String, dynamic>{
+      await SystemChannels.windowing.invokeMethod('createRegular', <String, dynamic>{
             'size': <double>[size.width, size.height],
             'minSize':
                 sizeConstraints != null

--- a/packages/flutter/lib/src/widgets/window.dart
+++ b/packages/flutter/lib/src/widgets/window.dart
@@ -5,16 +5,15 @@
 import 'dart:ui' show FlutterView;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
-/// Defines the type of the Window
+/// Defines the possible archetypes for a window.
 enum WindowArchetype {
   /// Defines a traditional window
   regular,
 }
 
-/// Defines the possible states a window can be in.
+/// Defines the possible states that a window can be in.
 enum WindowState {
   /// Window is in its normal state, neither maximized, nor minimized.
   restored,
@@ -26,24 +25,48 @@ enum WindowState {
   minimized,
 }
 
-/// Controller used with the [RegularWindow] widget. This controller
-/// provides access to modify and destroy the window, in addition to
-/// listening to changes on the window.
+/// Base class for window controllers.
+///
+/// A window controller must provide a [future] that resolves to a
+/// a [WindowCreationResult] object. This object contains the view
+/// associated with the window, the archetype of the window, the size
+/// of the window, and the state of the window.
+///
+/// The caller may also provide a callback to be called when the window
+/// is destroyed, and a callback to be called when an error is encountered
+/// during the creation of the window.
+///
+/// Each [WindowController] is associated with exactly one root [FlutterView].
+///
+/// When the window is destroyed for any reason (either by the caller or by the
+/// platform), the content of the controller will thereafter be invalid. Callers
+/// may check if this content is invalid via the [isReady] property.
+///
+/// This class implements the [Listenable] interface, so callers can listen
+/// for changes to the window's properties.
 abstract class WindowController with ChangeNotifier {
-  WindowController._({
+  /// Creates a [WindowController] with the provided properties.
+  /// Upon construction, this widget begins creating a window for the platform.
+  /// The [future] parameter is a future that resolves to a [WindowCreationResult]
+  /// object.
+  /// The [onDestroyed] parameter is a callback that is called when the window
+  /// is destroyed.
+  /// The [onError] parameter is a callback that is called when an error is
+  /// encountered during creation.
+  WindowController({
     VoidCallback? onDestroyed,
     void Function(String)? onError,
-    required Future<_WindowCreationResult> future,
-  }) : _future = future {
-    _future
-        .then((_WindowCreationResult metadata) async {
-          _view = metadata.view;
+    required this.future,
+  }) {
+    future
+        .then((WindowCreationResult metadata) async {
+          _view = metadata.rootView;
           _state = metadata.state;
           _size = metadata.size;
           notifyListeners();
 
           _listener = _WindowListener(
-            viewId: metadata.view.viewId,
+            viewId: metadata.rootView.viewId,
             onChanged: (_WindowChangeProperties properties) {
               if (properties.size != null) {
                 _size = properties.size!;
@@ -68,12 +91,13 @@ abstract class WindowController with ChangeNotifier {
   /// created and is ready to be used. Otherwise, returns false.
   bool get isReady => _view != null;
 
-  final Future<_WindowCreationResult> _future;
+  /// The future that resolves when the window has been created.
+  final Future<WindowCreationResult> future;
 
-  late _WindowListener _listener;
+  late final _WindowListener _listener;
 
-  /// The ID of the view used for this window, which is unique to each window.
-  FlutterView get view => _view!;
+  /// The root view associated to this window, which is unique to each window.
+  FlutterView get rootView => _view!;
   FlutterView? _view;
 
   /// The current size of the window. This may differ from the requested size.
@@ -89,21 +113,44 @@ abstract class WindowController with ChangeNotifier {
 
   bool _isPendingDestroy = false;
 
-  /// Destroys this window.
+  /// Destroys this window. If the window is not ready or is already pending
+  /// destruction, then nothing happens. Otherwise, we begin destroying the
+  /// window.
   Future<void> destroy() async {
     if (!isReady || _isPendingDestroy) {
       return;
     }
 
     _isPendingDestroy = true;
-    return _destroyWindow(view.viewId);
+    return _destroyWindow(rootView.viewId);
   }
 }
 
-/// Provided to [RegularWindow]. When this controller is initialized, a
-/// native window is created for the current platform. This controller
-/// can then be used to modify the window, listen to changes, or destroy
-/// the window.
+/// A controller for a regular window.
+///
+/// A regular window is a traditional window that can be resized, minimized,
+/// maximized, and closed. Upon construction, the window is created for the
+/// platform with the provided properties.
+///
+/// This class does not interact with the widget tree. Instead, it is typically
+/// provided to the [RegularWindow] widget, who does the work of rendering the
+/// content inside of this window.
+///
+/// An example usage might look like:
+/// ```dart
+/// final RegularWindowController controller = RegularWindowController(
+///   size: const Size(800, 600),
+///   sizeConstraints: const BoxConstraints(minWidth: 640, minHeight: 480),
+///   title: "Example Window",
+/// );
+/// runWidget(RegularWindow(
+///   controller: controller,
+///   child: MaterialApp(home: Container())));
+/// ```
+///
+/// When provided to a [RegularWindow] widget, widgets inside of the [child]
+/// parameter will have access to the [RegularWindowController] via the
+/// [WindowControllerContext] widget.
 class RegularWindowController extends WindowController {
   /// Creates a [RegularWindowController] with the provided properties.
   /// Upon construction, the window is created for the platform.
@@ -121,7 +168,7 @@ class RegularWindowController extends WindowController {
     VoidCallback? onDestroyed,
     void Function(String)? onError,
     required Size size,
-  }) : super._(
+  }) : super(
          onDestroyed: onDestroyed,
          onError: onError,
          future: _createRegular(
@@ -135,21 +182,51 @@ class RegularWindowController extends WindowController {
   @override
   WindowArchetype get type => WindowArchetype.regular;
 
-  /// Modify the properties of the window.
+  /// Modify the properties of the window. The window must be ready before
+  /// calling this method. If the window is not ready, an assertion will be
+  /// thrown. The caller must provide at least one of the following parameters:
+  ///
   /// [size] the new size of the window
   /// [title] the new title of the window
   /// [state] the new state of the window
+  ///
+  /// If no parameters are provided, then an assertion will be thrown.
   Future<void> modify({Size? size, String? title, WindowState? state}) {
     assert(isReady, 'Window is not ready');
-    return _modifyRegular(viewId: view.viewId, size: size, title: title, state: state);
+    return _modifyRegular(viewId: rootView.viewId, size: size, title: title, state: state);
   }
 }
 
-/// A widget that creates a regular window. This content of this window is
-/// rendered into a [View], meaning that this widget must be rendered into
-/// either a [ViewAnchor] or a [ViewCollection].
+/// The [RegularWindow] widget provides a way to render a regular window in the
+/// widget tree. The provided [controller] creates the native window that backs
+/// the widget. The [child] widget is rendered into this newly created window.
+///
+/// While the window is being created, the [RegularWindow] widget will render
+/// an empty [ViewCollection] widget. Once the window is created, the [child]
+/// widget will be rendered into the window inside of a [View].
+///
+/// An example usage might look like:
+/// ```dart
+/// final RegularWindowController controller = RegularWindowController(
+///   size: const Size(800, 600),
+///   sizeConstraints: const BoxConstraints(minWidth: 640, minHeight: 480),
+///   title: "Example Window",
+/// );
+/// runApp(RegularWindow(
+///   controller: controller,
+///   child: MaterialApp(home: Container())));
+/// ```
+///
+/// When a [RegularWindow] widget is removed from the tree, the window that was created
+/// by the [controller] is automatically destroyed if it has not yet been destroyed.
+///
+/// Widgets in the same tree as the [child] widget will have access to the
+/// [RegularWindowController] via the [WindowControllerContext] widget.
 class RegularWindow extends StatefulWidget {
-  /// Creates a regular window widget
+  /// Creates a regular window widget.
+  /// [controller] the controller for this window
+  /// [child] the content to render into this window
+  /// [key] the key for this widget
   const RegularWindow({super.key, required this.controller, required this.child});
 
   /// Controller for this widget.
@@ -166,24 +243,21 @@ class _RegularWindowState extends State<RegularWindow> {
   @override
   Future<void> dispose() async {
     super.dispose();
-
-    if (widget.controller.isReady && !widget.controller._isPendingDestroy) {
-      await widget.controller.destroy();
-    }
+    await widget.controller.destroy();
   }
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<_WindowCreationResult>(
+    return FutureBuilder<WindowCreationResult>(
       key: widget.key,
-      future: widget.controller._future,
-      builder: (BuildContext context, AsyncSnapshot<_WindowCreationResult> metadata) {
+      future: widget.controller.future,
+      builder: (BuildContext context, AsyncSnapshot<WindowCreationResult> metadata) {
         if (!metadata.hasData) {
           return const ViewCollection(views: <Widget>[]);
         }
 
         return View(
-          view: metadata.data!.view,
+          view: metadata.data!.rootView,
           child: WindowControllerContext(controller: widget.controller, child: widget.child),
         );
       },
@@ -191,8 +265,8 @@ class _RegularWindowState extends State<RegularWindow> {
   }
 }
 
-/// Provides descendents with access to the [WindowController] in which
-/// they are being rendered
+/// Provides descendents with access to the [WindowController] associated with
+/// the window that is being rendered.
 class WindowControllerContext extends InheritedWidget {
   /// Creates a new [WindowControllerContext]
   /// [controller] the controller associated with this window
@@ -213,35 +287,37 @@ class WindowControllerContext extends InheritedWidget {
   }
 }
 
-/// The raw data returned as a result of creating a window.
-class _WindowCreationResult {
-  /// Creates a new window.
-  _WindowCreationResult({
-    required this.view,
+/// Used by the [WindowController], this class defines the raw data
+/// associated with the creation of a window. This object can be constructed
+/// from anywhere, but it is typically returned by internal methods that create
+/// windows.
+class WindowCreationResult {
+  /// Creates a new [WindowCreationResult]
+  /// [rootView] the view associated with this window
+  /// [archetype] the archetype of this window
+  /// [size] the size of this window
+  /// [state] the state of this window
+  WindowCreationResult({
+    required this.rootView,
     required this.archetype,
     required this.size,
     this.state,
-    this.parent,
   });
 
-  /// The view associated with the window.
-  final FlutterView view;
+  /// The view associated with this window.
+  final FlutterView rootView;
 
-  /// The archetype of the window.
+  /// The archetype of this window.
   final WindowArchetype archetype;
 
-  /// The initial size of the window.
+  /// The size of this window.
   final Size size;
 
-  /// The initial state of the window.
-  /// Used by WindowArchetype.regular.
+  /// The state of this window.
   final WindowState? state;
-
-  /// The id of the window's parent, if any.
-  final int? parent;
 }
 
-Future<_WindowCreationResult> _createRegular({
+Future<WindowCreationResult> _createRegular({
   required Size size,
   BoxConstraints? sizeConstraints,
   String? title,
@@ -278,7 +354,7 @@ Future<void> _modifyRegular({required int viewId, Size? size, String? title, Win
   });
 }
 
-Future<_WindowCreationResult> _createWindow({
+Future<WindowCreationResult> _createWindow({
   required WindowArchetype archetype,
   required Future<Map<Object?, Object?>> Function(MethodChannel channel) viewBuilder,
 }) async {
@@ -303,8 +379,8 @@ Future<_WindowCreationResult> _createWindow({
     },
   );
 
-  return _WindowCreationResult(
-    view: flView,
+  return WindowCreationResult(
+    rootView: flView,
     archetype: archetype,
     size: Size(size[0]! as double, size[1]! as double),
     state: state,

--- a/packages/flutter/lib/src/widgets/window.dart
+++ b/packages/flutter/lib/src/widgets/window.dart
@@ -60,7 +60,7 @@ abstract class WindowController with ChangeNotifier {
   }) {
     future
         .then((WindowCreationResult metadata) async {
-          _handleCreationResult();
+          _handleCreationResult(metadata);
 
           _listener = _WindowListener(
             viewId: metadata.rootView.viewId,
@@ -84,7 +84,7 @@ abstract class WindowController with ChangeNotifier {
         });
   }
 
-  void _handleCreationResult(WindowCretionResult metadata) {
+  void _handleCreationResult(WindowCreationResult metadata) {
     _view = metadata.rootView;
     _size = metadata.size;
     notifyListeners();

--- a/packages/flutter/lib/src/widgets/window.dart
+++ b/packages/flutter/lib/src/widgets/window.dart
@@ -176,12 +176,7 @@ class RegularWindowController extends WindowController {
            title: title,
            state: state,
          ),
-       ) {
-    super.future.then((WindowCreationResult metadata) {
-      _state = (metadata as _RegularWindowCreationResult).state;
-      notifyListeners();
-    });
-  }
+       ) {}
 
   @override
   void _handleCreationResult(WindowCreationResult metadata) {

--- a/packages/flutter/test/widgets/window_test.dart
+++ b/packages/flutter/test/widgets/window_test.dart
@@ -13,7 +13,7 @@ Future<Object?>? Function(MethodCall)? _createWindowMethodCallHandler({
   return (MethodCall call) async {
     onMethodCall?.call(call);
     final Map<Object?, Object?> args = call.arguments as Map<Object?, Object?>;
-    if (call.method == 'createWindow') {
+    if (call.method == 'createRegular') {
       final List<Object?> size = args['size']! as List<Object?>;
       final String state = args['state'] as String? ?? WindowState.restored.toString();
 

--- a/packages/flutter/test/widgets/window_test.dart
+++ b/packages/flutter/test/widgets/window_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../rendering/proxy_box_test.dart';
-
 Future<Object?>? Function(MethodCall)? _createWindowMethodCallHandler({
   required WidgetTester tester,
   void Function(MethodCall)? onMethodCall,
@@ -55,7 +53,7 @@ void main() {
 
     expect(controller.type, WindowArchetype.regular);
     expect(controller.size, windowSize);
-    expect(controller.view.viewId, tester.view.viewId);
+    expect(controller.rootView.viewId, tester.view.viewId);
   });
 
   testWidgets('RegularWindow.onError is called when creation throws an error', (

--- a/packages/flutter/test/widgets/window_test.dart
+++ b/packages/flutter/test/widgets/window_test.dart
@@ -6,14 +6,22 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-Future<Object?>? Function(MethodCall)? _createWindowMethodCallHandler(WidgetTester tester) {
+import '../rendering/proxy_box_test.dart';
+
+Future<Object?>? Function(MethodCall)? _createWindowMethodCallHandler({
+  required WidgetTester tester,
+  void Function(MethodCall)? onMethodCall,
+}) {
   return (MethodCall call) async {
+    onMethodCall?.call(call);
     final Map<Object?, Object?> args = call.arguments as Map<Object?, Object?>;
     if (call.method == 'createWindow') {
       final List<Object?> size = args['size']! as List<Object?>;
       final String state = args['state'] as String? ?? WindowState.restored.toString();
 
       return <String, Object?>{'viewId': tester.view.viewId, 'size': size, 'state': state};
+    } else if (call.method == 'modifyRegular') {
+      return null;
     } else if (call.method == 'destroyWindow') {
       await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
         SystemChannels.windowing.name,
@@ -38,18 +46,10 @@ void main() {
 
     tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
       SystemChannels.windowing,
-      _createWindowMethodCallHandler(tester),
+      _createWindowMethodCallHandler(tester: tester),
     );
 
     final RegularWindowController controller = RegularWindowController(size: windowSize);
-    await tester.pumpWidget(
-      wrapWithView: false,
-      Builder(
-        builder: (BuildContext context) {
-          return RegularWindow(controller: controller, child: Container());
-        },
-      ),
-    );
 
     await tester.pump();
 
@@ -89,7 +89,7 @@ void main() {
 
     tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
       SystemChannels.windowing,
-      _createWindowMethodCallHandler(tester),
+      _createWindowMethodCallHandler(tester: tester),
     );
 
     bool destroyed = false;
@@ -123,19 +123,10 @@ void main() {
 
       tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
         SystemChannels.windowing,
-        _createWindowMethodCallHandler(tester),
+        _createWindowMethodCallHandler(tester: tester),
       );
 
       final RegularWindowController controller = RegularWindowController(size: initialSize);
-      await tester.pumpWidget(
-        wrapWithView: false,
-        Builder(
-          builder: (BuildContext context) {
-            return RegularWindow(controller: controller, child: Container());
-          },
-        ),
-      );
-
       await tester.pump();
 
       await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
@@ -153,4 +144,140 @@ void main() {
       expect(controller.size, newSize);
     },
   );
+
+  testWidgets('RegularWindowController.modify can be called when provided with a "size" argument', (
+    WidgetTester tester,
+  ) async {
+    const Size initialSize = Size(800, 600);
+    const Size newSize = Size(400, 300);
+
+    bool wasCalled = false;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.windowing,
+      _createWindowMethodCallHandler(
+        tester: tester,
+        onMethodCall: (MethodCall call) {
+          if (call.method != 'modifyRegular') {
+            return;
+          }
+
+          final Map<Object?, Object?> args = call.arguments as Map<Object?, Object?>;
+          final int viewId = args['viewId']! as int;
+          final List<Object?>? size = args['size'] as List<Object?>?;
+          final String? title = args['title'] as String?;
+          final String? state = args['state'] as String?;
+          expect(viewId, tester.view.viewId);
+          expect(size, <double>[newSize.width, newSize.height]);
+          expect(title, null);
+          expect(state, null);
+          wasCalled = true;
+        },
+      ),
+    );
+
+    final RegularWindowController controller = RegularWindowController(size: initialSize);
+    await tester.pump();
+
+    await controller.modify(size: newSize);
+    await tester.pump();
+
+    expect(wasCalled, true);
+  });
+
+  testWidgets(
+    'RegularWindowController.modify can be called when provided with a "title" argument',
+    (WidgetTester tester) async {
+      const Size initialSize = Size(800, 600);
+      const String newTitle = 'New Title';
+
+      bool wasCalled = false;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.windowing,
+        _createWindowMethodCallHandler(
+          tester: tester,
+          onMethodCall: (MethodCall call) {
+            if (call.method != 'modifyRegular') {
+              return;
+            }
+
+            final Map<Object?, Object?> args = call.arguments as Map<Object?, Object?>;
+            final int viewId = args['viewId']! as int;
+            final List<Object?>? size = args['size'] as List<Object?>?;
+            final String? title = args['title'] as String?;
+            final String? state = args['state'] as String?;
+            expect(viewId, tester.view.viewId);
+            expect(size, null);
+            expect(title, newTitle);
+            expect(state, null);
+            wasCalled = true;
+          },
+        ),
+      );
+
+      final RegularWindowController controller = RegularWindowController(size: initialSize);
+      await tester.pump();
+
+      await controller.modify(title: newTitle);
+      await tester.pump();
+
+      expect(wasCalled, true);
+    },
+  );
+
+  testWidgets(
+    'RegularWindowController.modify can be called when provided with a "state" argument',
+    (WidgetTester tester) async {
+      const Size initialSize = Size(800, 600);
+      const WindowState newState = WindowState.minimized;
+
+      bool wasCalled = false;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.windowing,
+        _createWindowMethodCallHandler(
+          tester: tester,
+          onMethodCall: (MethodCall call) {
+            if (call.method != 'modifyRegular') {
+              return;
+            }
+
+            final Map<Object?, Object?> args = call.arguments as Map<Object?, Object?>;
+            final int viewId = args['viewId']! as int;
+            final List<Object?>? size = args['size'] as List<Object?>?;
+            final String? title = args['title'] as String?;
+            final String? state = args['state'] as String?;
+            expect(viewId, tester.view.viewId);
+            expect(size, null);
+            expect(title, null);
+            expect(state, newState.toString());
+            wasCalled = true;
+          },
+        ),
+      );
+
+      final RegularWindowController controller = RegularWindowController(size: initialSize);
+      await tester.pump();
+
+      await controller.modify(state: newState);
+      await tester.pump();
+
+      expect(wasCalled, true);
+    },
+  );
+
+  testWidgets('RegularWindowController.modify throws when no arguments are provided', (
+    WidgetTester tester,
+  ) async {
+    const Size initialSize = Size(800, 600);
+    const WindowState newState = WindowState.minimized;
+
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.windowing,
+      _createWindowMethodCallHandler(tester: tester),
+    );
+
+    final RegularWindowController controller = RegularWindowController(size: initialSize);
+    await tester.pump();
+
+    expect(() async => controller.modify(), throwsA(isA<AssertionError>()));
+  });
 }


### PR DESCRIPTION
## What's new?
- Implemented `modifyRegular` + wrote tests for it
- Also realized that the `SchedulerBinding.instance.addPostFrameCallback...` wrapper around the listener was leftover cruft that was causing our tests to break when they lacked a widget, which is incorrect!