### PR TITLE
Simplify focusing the root view when the top-level window is activated

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.cc
@@ -489,12 +489,6 @@ WindowState FlutterHostWindow::GetState() const {
   return state_;
 }
 
-void FlutterHostWindow::FocusViewOf(FlutterHostWindow* window) {
-  if (window != nullptr && window->child_content_ != nullptr) {
-    SetFocus(window->child_content_);
-  }
-};
-
 LRESULT FlutterHostWindow::WndProc(HWND hwnd,
                                    UINT message,
                                    WPARAM wparam,
@@ -588,12 +582,10 @@ LRESULT FlutterHostWindow::HandleMessage(HWND hwnd,
     }
 
     case WM_ACTIVATE:
-      FocusViewOf(this);
+      if (LOWORD(wparam) != WA_INACTIVE && child_content_ != nullptr) {
+        SetFocus(child_content_);
+      }
       return 0;
-
-    case WM_MOUSEACTIVATE:
-      FocusViewOf(this);
-      return MA_ACTIVATE;
 
     case WM_DWMCOLORIZATIONCOLORCHANGED:
       UpdateTheme(hwnd);

--- a/engine/src/flutter/shell/platform/windows/flutter_host_window.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_host_window.h
@@ -49,9 +49,6 @@ class FlutterHostWindow {
  private:
   friend FlutterHostWindowController;
 
-  // Sets the focus to the child view window of |window|.
-  static void FocusViewOf(FlutterHostWindow* window);
-
   // OS callback called by message pump. Handles the WM_NCCREATE message which
   // is passed when the non-client area is being created and enables automatic
   // non-client DPI scaling so that the non-client area automatically


### PR DESCRIPTION
This simplifies the logic for focusing the root view when the top-level window is activated. It removes the handling of `WM_MOUSEACTIVATE`, as `WM_ACTIVATE` already accounts for activations via mouse clicks. Additionally, it ensures that the view is not focused when the top-level window is being deactivated.