### PR TITLE
Update reference app to ensure root views of regular windows remain in the same view collection

### DIFF
--- a/examples/multi_window_ref_app/lib/app/main_window.dart
+++ b/examples/multi_window_ref_app/lib/app/main_window.dart
@@ -1,19 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:multi_window_ref_app/app/window_controller_render.dart';
 
+import 'window_controller_render.dart';
 import 'window_settings.dart';
 import 'window_settings_dialog.dart';
 import 'window_manager_model.dart';
 import 'regular_window_edit_dialog.dart';
 
 class MainWindow extends StatefulWidget {
-  MainWindow({super.key, required WindowController mainController}) {
-    _windowManagerModel.add(KeyedWindowController(
-        isMainWindow: true, key: UniqueKey(), controller: mainController));
-  }
+  const MainWindow(
+      {super.key,
+      required this.controller,
+      required this.settings,
+      required this.windowManagerModel});
 
-  final WindowManagerModel _windowManagerModel = WindowManagerModel();
-  final WindowSettings _settings = WindowSettings();
+  final WindowController controller;
+  final WindowSettings settings;
+  final WindowManagerModel windowManagerModel;
 
   @override
   State<MainWindow> createState() => _MainWindowState();
@@ -34,7 +36,7 @@ class _MainWindowState extends State<MainWindow> {
             child: SingleChildScrollView(
               scrollDirection: Axis.vertical,
               child: _ActiveWindowsTable(
-                  windowManagerModel: widget._windowManagerModel),
+                  windowManagerModel: widget.windowManagerModel),
             ),
           ),
           Expanded(
@@ -43,12 +45,12 @@ class _MainWindowState extends State<MainWindow> {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 ListenableBuilder(
-                    listenable: widget._windowManagerModel,
+                    listenable: widget.windowManagerModel,
                     builder: (BuildContext context, Widget? child) {
                       return _WindowCreatorCard(
-                          selectedWindow: widget._windowManagerModel.selected,
-                          windowManagerModel: widget._windowManagerModel,
-                          windowSettings: widget._settings);
+                          selectedWindow: widget.windowManagerModel.selected,
+                          windowManagerModel: widget.windowManagerModel,
+                          windowSettings: widget.settings);
                     })
               ],
             ),
@@ -59,21 +61,21 @@ class _MainWindowState extends State<MainWindow> {
 
     return ViewAnchor(
         view: ListenableBuilder(
-            listenable: widget._windowManagerModel,
+            listenable: widget.windowManagerModel,
             builder: (BuildContext context, Widget? _) {
               final List<Widget> childViews = <Widget>[];
               for (final KeyedWindowController controller
-                  in widget._windowManagerModel.windows) {
-                if (controller.parent == null && !controller.isMainWindow) {
+                  in widget.windowManagerModel.windows) {
+                if (controller.parent == widget.controller) {
                   childViews.add(WindowControllerRender(
                     controller: controller.controller,
                     key: controller.key,
-                    windowSettings: widget._settings,
-                    windowManagerModel: widget._windowManagerModel,
+                    windowSettings: widget.settings,
+                    windowManagerModel: widget.windowManagerModel,
                     onDestroyed: () =>
-                        widget._windowManagerModel.remove(controller.key),
+                        widget.windowManagerModel.remove(controller.key),
                     onError: () =>
-                        widget._windowManagerModel.remove(controller.key),
+                        widget.windowManagerModel.remove(controller.key),
                   ));
                 }
               }

--- a/examples/multi_window_ref_app/lib/app/window_controller_render.dart
+++ b/examples/multi_window_ref_app/lib/app/window_controller_render.dart
@@ -25,10 +25,11 @@ class WindowControllerRender extends StatelessWidget {
         return RegularWindow(
             key: key,
             controller: controller as RegularWindowController,
-            child: RegularWindowContent(
-                window: controller as RegularWindowController,
-                windowSettings: windowSettings,
-                windowManagerModel: windowManagerModel));
+            child: MaterialApp(
+                home: RegularWindowContent(
+                    window: controller as RegularWindowController,
+                    windowSettings: windowSettings,
+                    windowManagerModel: windowManagerModel)));
       default:
         throw UnimplementedError(
             "The provided window type does not have an implementation");

--- a/examples/multi_window_ref_app/lib/main.dart
+++ b/examples/multi_window_ref_app/lib/main.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'app/main_window.dart';
+import 'app/window_controller_render.dart';
+import 'app/window_settings.dart';
+import 'app/window_manager_model.dart';
 
 void main() {
   final RegularWindowController controller = RegularWindowController(
@@ -7,7 +10,39 @@ void main() {
     sizeConstraints: const BoxConstraints(minWidth: 640, minHeight: 480),
     title: "Multi-Window Reference Application",
   );
-  runWidget(RegularWindow(
-      controller: controller,
-      child: MaterialApp(home: MainWindow(mainController: controller))));
+
+  final WindowSettings settings = WindowSettings();
+  final WindowManagerModel windowManagerModel = WindowManagerModel();
+  windowManagerModel.add(KeyedWindowController(
+      isMainWindow: true, key: UniqueKey(), controller: controller));
+
+  runWidget(
+    ListenableBuilder(
+        listenable: windowManagerModel,
+        builder: (BuildContext context, Widget? _) {
+          final List<Widget> childViews = <Widget>[
+            RegularWindow(
+                controller: controller,
+                child: MaterialApp(
+                    home: MainWindow(
+                        controller: controller,
+                        settings: settings,
+                        windowManagerModel: windowManagerModel))),
+          ];
+          for (final KeyedWindowController controller
+              in windowManagerModel.windows) {
+            if (controller.parent == null && !controller.isMainWindow) {
+              childViews.add(WindowControllerRender(
+                controller: controller.controller,
+                key: controller.key,
+                windowSettings: settings,
+                windowManagerModel: windowManagerModel,
+                onDestroyed: () => windowManagerModel.remove(controller.key),
+                onError: () => windowManagerModel.remove(controller.key),
+              ));
+            }
+          }
+          return ViewCollection(views: childViews);
+        }),
+  );
 }


### PR DESCRIPTION
This PR updates the reference app so that the root view of a regular window stays in the topmost view collection instead of being anchored to the view of the main window. This ensures that the `FocusTraversalGroup` of the root view is a child of the root focus scope rather than a nested scope.

Why does this matter? Because it fixes an issue where focus sometimes switches back and forth indefinitely between two regular windows. Specifically, the issue occurs when switching focus from a root view A to a root view B while B's focus scope is nested in A's focus scope. When the user activates the top-level window with root view B and the focus goes to B, A's `View::_scopeFocusChangeListener` detects that the focused scope does not match the newly focused view (B) and requests a focus change back to A. However, when A regains focus, B's `View::_scopeFocusChangeListener` then notices that B is not focused while its scope node is (since it's inside A's scope) and requests a focus change to B, restarting the loop.