### PR TITLE
Enable windowing with `flutter config`

### DIFF
--- a/engine/src/flutter/common/settings.h
+++ b/engine/src/flutter/common/settings.h
@@ -363,7 +363,7 @@ struct Settings {
 
   // Enable support for multiple windows. Ignored if not supported on the
   // platform.
-  bool enable_multi_window = false;
+  bool enable_windowing = false;
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/common/switches.cc
+++ b/engine/src/flutter/shell/common/switches.cc
@@ -536,16 +536,17 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
       command_line.HasOption(FlagForSwitch(Switch::ImpellerLazyShaderMode));
   settings.impeller_antialiased_lines =
       command_line.HasOption(FlagForSwitch(Switch::ImpellerAntialiasLines));
-#if FML_OS_WIN
-  // Process the EnableMultiWindow switch on Windows.
+
+#if FML_OS_MACOSX || FML_OS_LINUX || FML_OS_WIN
+  // Process the EnableWindowing switch on macOS, Linux, and Windows.
   {
-    std::string enable_multi_window_value;
-    if (command_line.GetOptionValue(FlagForSwitch(Switch::EnableMultiWindow),
-                                    &enable_multi_window_value)) {
-      settings.enable_multi_window = "true" == enable_multi_window_value;
+    std::string enable_windowing_value;
+    if (command_line.GetOptionValue(FlagForSwitch(Switch::EnableWindowing),
+                                    &enable_windowing_value)) {
+      settings.enable_windowing = "true" == enable_windowing_value;
     }
   }
-#endif  // FML_OS_WIN
+#endif  // FML_OS_MACOSX || FML_OS_LINUX || FML_OS_WIN
 
   return settings;
 }

--- a/engine/src/flutter/shell/common/switches.h
+++ b/engine/src/flutter/shell/common/switches.h
@@ -297,8 +297,8 @@ DEF_SWITCH(EnablePlatformIsolates,
 DEF_SWITCH(DisableMergedPlatformUIThread,
            "no-enable-merged-platform-ui-thread",
            "Merge the ui thread and platform thread.")
-DEF_SWITCH(EnableMultiWindow,
-           "enable-multi-window",
+DEF_SWITCH(EnableWindowing,
+           "enable-windowing",
            "Enable support for multiple windows. Ignored if not supported on "
            "the platform.")
 DEF_SWITCH(EnableAndroidSurfaceControl,

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
@@ -196,9 +196,8 @@ FlutterWindowsEngine::FlutterWindowsEngine(
   enable_impeller_ = std::find(switches.begin(), switches.end(),
                                "--enable-impeller=true") != switches.end();
 
-  enable_multi_window_ =
-      std::find(switches.begin(), switches.end(),
-                "--enable-multi-window=true") != switches.end();
+  enable_windowing_ = std::find(switches.begin(), switches.end(),
+                                "--enable-windowing=true") != switches.end();
 
   egl_manager_ = egl::Manager::Create(
       static_cast<egl::GpuPreference>(project_->gpu_preference()));
@@ -239,7 +238,7 @@ FlutterWindowsEngine::FlutterWindowsEngine(
       std::make_unique<CursorHandler>(messenger_wrapper_.get(), this);
   platform_handler_ =
       std::make_unique<PlatformHandler>(messenger_wrapper_.get(), this);
-  if (enable_multi_window_) {
+  if (enable_windowing_) {
     host_window_controller_ =
         std::make_unique<FlutterHostWindowController>(this);
   }
@@ -321,7 +320,7 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
 
   if (project_->ui_thread_policy() ==
           FlutterUIThreadPolicy::RunOnPlatformThread ||
-      enable_multi_window_) {
+      enable_windowing_) {
     FML_LOG(WARNING)
         << "Running with merged platform and UI thread. Experimental.";
     custom_task_runners.ui_task_runner = &platform_task_runner;

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
@@ -494,7 +494,7 @@ class FlutterWindowsEngine {
 
   bool enable_impeller_ = false;
 
-  bool enable_multi_window_ = false;
+  bool enable_windowing_ = false;
 
   // The manager for WindowProc delegate registration and callbacks.
   std::unique_ptr<WindowProcDelegateManager> window_proc_delegate_manager_;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -220,7 +220,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
     addEnableImpellerFlag(verboseHelp: verboseHelp);
     addEnableVulkanValidationFlag(verboseHelp: verboseHelp);
     addEnableEmbedderApiFlag(verboseHelp: verboseHelp);
-    addMultiWindowFlag(verboseHelp: verboseHelp);
+    addWindowingFlag(verboseHelp: verboseHelp);
   }
 
   bool get traceStartup => boolArg('trace-startup');
@@ -236,7 +236,6 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   bool get enableVulkanValidation => boolArg('enable-vulkan-validation');
   bool get uninstallFirst => boolArg('uninstall-first');
   bool get enableEmbedderApi => boolArg('enable-embedder-api');
-  bool get enableMultiWindow => boolArg('enable-multi-window');
 
   @override
   bool get refreshWirelessDevices => true;
@@ -303,7 +302,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         uninstallFirst: uninstallFirst,
         enableDartProfiling: enableDartProfiling,
         enableEmbedderApi: enableEmbedderApi,
-        enableMultiWindow: enableMultiWindow,
+        enableWindowing: featureFlags.isWindowingEnabled,
         usingCISystem: usingCISystem,
         debugLogsDirectoryPath: debugLogsDirectoryPath,
       );
@@ -369,7 +368,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         serveObservatory: boolArg('serve-observatory'),
         enableDartProfiling: enableDartProfiling,
         enableEmbedderApi: enableEmbedderApi,
-        enableMultiWindow: enableMultiWindow,
+        enableWindowing: featureFlags.isWindowingEnabled,
         usingCISystem: usingCISystem,
         debugLogsDirectoryPath: debugLogsDirectoryPath,
         enableDevTools: boolArg(FlutterCommand.kEnableDevTools),

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -78,7 +78,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     usesDeviceUserOption();
     usesFlavorOption();
     addEnableImpellerFlag(verboseHelp: verboseHelp);
-    addMultiWindowFlag(verboseHelp: verboseHelp);
+    addWindowingFlag(verboseHelp: verboseHelp);
 
     argParser
       ..addFlag(

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -304,8 +304,7 @@ class CustomDeviceAppSession {
         if (debuggingOptions.useTestFonts) 'use-test-fonts=true',
         if (debuggingOptions.verboseSystemLogs) 'verbose-logging=true',
       ],
-      if (debuggingOptions.enableMultiWindow)
-        'enable-multi-window=true',
+      if (debuggingOptions.enableWindowing) 'enable-windowing=true',
     ];
   }
 

--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -295,8 +295,8 @@ abstract class DesktopDevice extends Device {
       case ImpellerStatus.platformDefault:
         addFlag('enable-impeller=false');
     }
-    if (debuggingOptions.enableMultiWindow) {
-      addFlag('enable-multi-window=true');
+    if (debuggingOptions.enableWindowing) {
+      addFlag('enable-windowing=true');
     }
     // Options only supported when there is a VM Service connection between the
     // tool and the device, usually in debug or profile mode.

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -971,7 +971,7 @@ class DebuggingOptions {
     this.serveObservatory = false,
     this.enableDartProfiling = true,
     this.enableEmbedderApi = false,
-    this.enableMultiWindow = false,
+    this.enableWindowing = false,
     this.usingCISystem = false,
     this.debugLogsDirectoryPath,
     this.enableDevTools = true,
@@ -1005,7 +1005,7 @@ class DebuggingOptions {
     this.uninstallFirst = false,
     this.enableDartProfiling = true,
     this.enableEmbedderApi = false,
-    this.enableMultiWindow = false,
+    this.enableWindowing = false,
     this.usingCISystem = false,
     this.debugLogsDirectoryPath,
   }) : debuggingEnabled = false,
@@ -1090,7 +1090,7 @@ class DebuggingOptions {
     required this.serveObservatory,
     required this.enableDartProfiling,
     required this.enableEmbedderApi,
-    required this.enableMultiWindow,
+    required this.enableWindowing,
     required this.usingCISystem,
     required this.debugLogsDirectoryPath,
     required this.enableDevTools,
@@ -1137,7 +1137,7 @@ class DebuggingOptions {
   final bool serveObservatory;
   final bool enableDartProfiling;
   final bool enableEmbedderApi;
-  final bool enableMultiWindow;
+  final bool enableWindowing;
   final bool usingCISystem;
   final String? debugLogsDirectoryPath;
   final bool enableDevTools;
@@ -1237,7 +1237,7 @@ class DebuggingOptions {
       if (interfaceType == DeviceConnectionInterface.wireless)
         '--vm-service-host=${ipv6 ? '::0' : '0.0.0.0'}',
       if (enableEmbedderApi) '--enable-embedder-api',
-      if (enableMultiWindow) '--enable-multi-window=true',
+      if (enableWindowing) '--enable-windowing=true',
     ];
   }
 
@@ -1289,7 +1289,7 @@ class DebuggingOptions {
     'serveObservatory': serveObservatory,
     'enableDartProfiling': enableDartProfiling,
     'enableEmbedderApi': enableEmbedderApi,
-    'enableMultiWindow': enableMultiWindow,
+    'enableWindowing': enableWindowing,
     'usingCISystem': usingCISystem,
     'debugLogsDirectoryPath': debugLogsDirectoryPath,
     'enableDevTools': enableDevTools,
@@ -1360,7 +1360,7 @@ class DebuggingOptions {
         serveObservatory: (json['serveObservatory'] as bool?) ?? false,
         enableDartProfiling: (json['enableDartProfiling'] as bool?) ?? true,
         enableEmbedderApi: (json['enableEmbedderApi'] as bool?) ?? false,
-        enableMultiWindow: (json['enableMultiWindow']! as bool?) ?? false,
+        enableWindowing: (json['enableWindowing']! as bool?) ?? false,
         usingCISystem: (json['usingCISystem'] as bool?) ?? false,
         debugLogsDirectoryPath: json['debugLogsDirectoryPath'] as String?,
         enableDevTools: (json['enableDevTools'] as bool?) ?? true,

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -54,6 +54,9 @@ abstract class FeatureFlags {
   /// Whether explicit package dependency management is enabled.
   bool get isExplicitPackageDependenciesEnabled => false;
 
+  /// Whether multi-window support is enabled.
+  bool get isWindowingEnabled => false;
+
   /// Whether a particular feature is enabled for the current channel.
   ///
   /// Prefer using one of the specific getters above instead of this API.
@@ -74,6 +77,7 @@ const List<Feature> allFeatures = <Feature>[
   nativeAssets,
   swiftPackageManager,
   explicitPackageDependencies,
+  windowing,
 ];
 
 /// All current Flutter feature flags that can be configured.
@@ -178,6 +182,16 @@ const Feature explicitPackageDependencies = Feature.fullyEnabled(
       'See also:\n'
       '* https://flutter.dev/to/flutter-plugins-configuration.\n'
       '* https://flutter.dev/to/flutter-gen-deprecation.',
+);
+
+/// Enable multi-window support.
+const Feature windowing = Feature(
+  name: 'support for multiple windows',
+  configSetting: 'enable-windowing',
+  environmentOverride: 'FLUTTER_WINDOWING',
+  master: FeatureChannelSetting(available: true),
+  beta: FeatureChannelSetting(available: true),
+  stable: FeatureChannelSetting(available: true),
 );
 
 /// A [Feature] is a process for conditionally enabling tool features.

--- a/packages/flutter_tools/lib/src/flutter_features.dart
+++ b/packages/flutter_tools/lib/src/flutter_features.dart
@@ -62,6 +62,9 @@ class FlutterFeatureFlags implements FeatureFlags {
   bool get isExplicitPackageDependenciesEnabled => isEnabled(explicitPackageDependencies);
 
   @override
+  bool get isWindowingEnabled => isEnabled(windowing);
+
+  @override
   bool isEnabled(Feature feature) {
     final String currentChannel = _flutterVersion.channel;
     final FeatureChannelSetting featureSetting = feature.getSettingForChannel(currentChannel);

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1290,12 +1290,12 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
-  void addMultiWindowFlag({required bool verboseHelp}) {
-    argParser.addFlag('enable-multi-window',
+  void addWindowingFlag({required bool verboseHelp}) {
+    argParser.addFlag('enable-windowing',
         hide: !verboseHelp,
         help: 'Whether to enable support for multiple windows. '
-              'This flag is only available on Windows, is disabled by default, '
-              'and will be ignored on other platforms.',
+              'Disabled by default. Ignored on platforms other than '
+              'macOS, Linux, and Windows.',
     );
   }
 

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -424,5 +424,29 @@ void main() {
         expect(featureFlags.isSwiftPackageManagerEnabled, isTrue);
       });
     });
+
+    test('Windowing availability and default enabled', () {
+      expect(windowing.master.enabledByDefault, false);
+      expect(windowing.master.available, true);
+      expect(windowing.beta.enabledByDefault, false);
+      expect(windowing.beta.available, true);
+      expect(windowing.stable.enabledByDefault, false);
+      expect(windowing.stable.available, true);
+    });
+
+    for (final String channel in <String>['master', 'beta', 'stable']) {
+      testWithoutContext('Windowing can be enabled with flag on $channel', () {
+        final FeatureFlags featureFlags = createFlags(channel);
+        testConfig.setValue('enable-windowing', true);
+        expect(featureFlags.isWindowingEnabled, true);
+      });
+
+      testWithoutContext('Windowing can be enabled with environment variable on $channel', () {
+        final FeatureFlags featureFlags = createFlags(channel);
+        platform.environment = <String, String>{'FLUTTER_WINDOWING': 'true'};
+        expect(featureFlags.isWindowingEnabled, true);
+      });
+    }
+
   });
 }

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -494,6 +494,7 @@ class TestFeatureFlags implements FeatureFlags {
     this.isNativeAssetsEnabled = false,
     this.isSwiftPackageManagerEnabled = false,
     this.isExplicitPackageDependenciesEnabled = false,
+    this.isWindowingEnabled = false,
   });
 
   @override
@@ -533,6 +534,9 @@ class TestFeatureFlags implements FeatureFlags {
   final bool isExplicitPackageDependenciesEnabled;
 
   @override
+  final bool isWindowingEnabled;
+
+  @override
   bool isEnabled(Feature feature) {
     return switch (feature) {
       flutterWebFeature => isWebEnabled,
@@ -546,6 +550,7 @@ class TestFeatureFlags implements FeatureFlags {
       cliAnimation => isCliAnimationEnabled,
       nativeAssets => isNativeAssetsEnabled,
       explicitPackageDependencies => isExplicitPackageDependenciesEnabled,
+      windowing => isWindowingEnabled,
       _ => false,
     };
   }


### PR DESCRIPTION
## What's new
Multi-window support is now enabled via `flutter config --enable-windowing`. This replaces the `--enable-multi-window=true` flag previously passed as an argument to `flutter run`.

`--enable-windowing` is available on `master`, `beta` and `stable` branches, but disabled by default. It takes effect only on macOS, Linux, and Windows.

When running the executable directly, continue setting the environment variable for engine switches as before. Note that `enable-multi-window` has been renamed to `enable-windowing`:
```
FLUTTER_ENGINE_SWITCHES=1
FLUTTER_ENGINE_SWITCH_1=enable-windowing
```